### PR TITLE
Add language override via settings file

### DIFF
--- a/usage_monitor_for_claude/i18n.py
+++ b/usage_monitor_for_claude/i18n.py
@@ -49,10 +49,38 @@ def detect_lang_code(lang: str) -> str:
     return 'en'
 
 
+def _read_language_override() -> str:
+    """Read the ``language`` key from ``usage-monitor-settings.json``, if present."""
+    import sys
+
+    settings_filename = 'usage-monitor-settings.json'
+
+    if getattr(sys, 'frozen', False):
+        app_dir = Path(sys.executable).parent
+    else:
+        app_dir = Path(__file__).resolve().parent.parent
+
+    for path in (app_dir / settings_filename, Path.home() / '.claude' / settings_filename):
+        if path.is_file():
+            try:
+                data = json.loads(path.read_text(encoding='utf-8').strip())
+                if isinstance(data, dict) and 'language' in data:
+                    return str(data['language'])
+            except (json.JSONDecodeError, OSError):
+                pass
+
+    return ''
+
+
 def load_translations() -> dict[str, Any]:
     """Load translations for the detected system language, fallback to English."""
-    lang = locale.getlocale()[0] or ''
-    lang_code = detect_lang_code(lang)
+    override = _read_language_override()
+
+    if override:
+        lang_code = override if (LOCALE_DIR / f'{override}.json').exists() else 'en'
+    else:
+        lang = locale.getlocale()[0] or ''
+        lang_code = detect_lang_code(lang)
 
     return json.loads((LOCALE_DIR / f'{lang_code}.json').read_text(encoding='utf-8'))
 


### PR DESCRIPTION
## Problem

On Windows, `locale.getlocale()` returns the **regional format** (e.g. `de_CH`) rather than the **display language** (e.g. `en_US`). This is common in multilingual regions like Switzerland, Belgium, and Canada where users set their regional format to one language but their Windows display language to another.

As a result, the app shows the wrong UI language — for example, German instead of English for a user with `de-CH` regional format but English display language.

## Solution

Added support for a `"language"` key in `usage-monitor-settings.json` that overrides the auto-detected locale. When not set, the existing auto-detection behavior is preserved.

### Usage

Add to `usage-monitor-settings.json`:
```json
{
    "language": "en"
}
```

Valid values match the locale file names: `en`, `de`, `fr`, `es`, `pt-BR`, `it`, `ja`, `ko`, `hi`, `id`, `zh-CN`, `zh-TW`.

## Implementation details

- New `_read_language_override()` function in `i18n.py` reads the settings file using the same search order as `settings.py` (next to exe, then `~/.claude/`)
- Falls back to `en` if the specified language file doesn't exist
- No changes to `settings.py` — the override is read directly in `i18n.py` since translations must load before settings validation
- Zero impact on existing behavior when the key is not present