### PR TITLE
Add per-variant event commands (on_reset_command / on_threshold_command as variant-keyed object)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [Per-variant event commands](https://github.com/jens-duttke/usage-monitor-for-claude/issues/34) - `on_reset_command` and `on_threshold_command` now accept an object keyed by quota variant (e.g. `{"five_hour": "...", "seven_day": "..."}`) to run different commands per quota type, or to target only specific variants; existing string and array forms continue to work unchanged
 - [Dim usage bars when data is stale](https://github.com/jens-duttke/usage-monitor-for-claude/discussions/28) - the usage section fades to 40% opacity when no successful update has been received for longer than the poll interval, clearly indicating that the displayed data may be outdated
 - Account switch notification - switching to a different Claude account now shows an "Account Switched" notification with the new account's email address instead of a misleading "Quota Reset" notification
 - Overage bar mode for tray icon bars - each entry in `icon_fields` now accepts an optional `:overage` suffix (e.g. `"five_hour:overage"`) to switch that bar to an over-budget view: the bar is empty when usage is at or below the time marker (on pace or ahead) and fills proportionally as usage climbs toward 100%, making it immediately visible how far you have overrun your expected pace

--- a/docs/event-commands.md
+++ b/docs/event-commands.md
@@ -15,6 +15,19 @@ Commands run with the same privileges as the app and **without a visible window*
 
 Both settings accept a single command string or an array of strings to run multiple commands per event. When an array is provided, all commands are launched independently (fire-and-forget) - if one fails, the others still run.
 
+Both settings also accept an **object keyed by quota variant** to run different commands per quota type, or to target only specific variants:
+
+```json
+{
+  "on_reset_command": {
+    "five_hour": "claude -p \"ok\" --tools \"\" --no-session-persistence --system-prompt \"Reply with only: ok\" --output-format text",
+    "seven_day": "echo weekly reset"
+  }
+}
+```
+
+With a variant object, a command only fires when the matching quota variant resets or crosses a threshold. Variants not listed in the object are silently ignored. Each variant's value can be a string or an array of strings.
+
 Commands only fire on **state changes** detected while the app is running. On app startup, already-exceeded thresholds trigger a desktop notification but do not run `on_threshold_command` - this prevents duplicate commands after a restart or reboot.
 
 When `on_reset_command` is configured, the app briefly wakes from idle/lock pause to poll at the expected reset time so the command fires promptly - even if the computer is unattended. If the API has not applied the reset yet (server-side delay) or the network is temporarily unavailable, the app retries at regular intervals until the reset is confirmed. `on_threshold_command` does not wake from idle - thresholds are driven by active usage, so they are checked when polling resumes after the user returns. Desktop notifications that occur during idle are deferred and shown when the user returns.
@@ -29,6 +42,25 @@ When `on_reset_command` is configured, the app briefly wakes from idle/lock paus
 > Use the **Test event commands** submenu in the tray context menu to fire your configured commands with sample data. This lets you verify your command and script setup without waiting for a real event.
 
 ## Examples
+
+### Quota trigger - ping Claude the moment the 5h session resets
+
+Send a minimal Claude Code request the instant the 5-hour quota resets so the
+next cooldown window starts immediately, without waiting for you to send your
+first real message. Using the variant object ensures the ping only fires on
+session resets - not on weekly or Sonnet quota resets.
+
+```json
+{
+  "on_reset_command": {
+    "five_hour": "claude -p \"ok\" --tools \"\" --no-session-persistence --system-prompt \"Reply with only: ok\" --output-format text"
+  }
+}
+```
+
+The app is already idle-aware and aligns its polling to imminent reset times,
+so the trigger fires within seconds of the actual reset even when the computer
+has been idle.
 
 ### Resume a Claude Code session when the quota resets
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1532,6 +1532,56 @@ class TestResetCommand(unittest.TestCase):
         self.app.icon.notify.assert_not_called()
 
 
+    @patch('usage_monitor_for_claude.app.ON_RESET_COMMAND', {'five_hour': ['echo ping']})
+    @patch('usage_monitor_for_claude.app.run_event_command')
+    @patch('usage_monitor_for_claude.app.format_tooltip', return_value='tooltip')
+    @patch('usage_monitor_for_claude.app.create_icon_image')
+    def test_dict_command_fires_for_matching_variant(self, _icon, _tooltip, mock_cmd):
+        """Per-variant dict: command fires when the dropping variant is in the dict."""
+        self.app._prev_utilization = {'five_hour': 95.0, 'seven_day': 10.0}
+        data = {'five_hour': {'utilization': 5.0}, 'seven_day': {'utilization': 10.0}}
+        self.app.cache = MagicMock()
+        self.app.cache.update.return_value = UpdateResult(data=data)
+
+        self.app.update()
+
+        mock_cmd.assert_called_once()
+        self.assertEqual(mock_cmd.call_args[0][0], ['echo ping'])
+        self.assertEqual(mock_cmd.call_args[0][1]['USAGE_MONITOR_VARIANT'], 'five_hour')
+
+    @patch('usage_monitor_for_claude.app.ON_RESET_COMMAND', {'five_hour': ['echo ping']})
+    @patch('usage_monitor_for_claude.app.run_event_command')
+    @patch('usage_monitor_for_claude.app.format_tooltip', return_value='tooltip')
+    @patch('usage_monitor_for_claude.app.create_icon_image')
+    def test_dict_command_silent_for_unmatched_variant(self, _icon, _tooltip, mock_cmd):
+        """Per-variant dict: no command fires when the dropping variant is not in the dict."""
+        self.app._prev_utilization = {'five_hour': 10.0, 'seven_day': 90.0}
+        data = {'five_hour': {'utilization': 10.0}, 'seven_day': {'utilization': 5.0}}
+        self.app.cache = MagicMock()
+        self.app.cache.update.return_value = UpdateResult(data=data)
+
+        self.app.update()
+
+        mock_cmd.assert_not_called()
+
+    @patch('usage_monitor_for_claude.app.ON_RESET_COMMAND', {'five_hour': ['echo 5h'], 'seven_day': ['echo 7d']})
+    @patch('usage_monitor_for_claude.app.run_event_command')
+    @patch('usage_monitor_for_claude.app.format_tooltip', return_value='tooltip')
+    @patch('usage_monitor_for_claude.app.create_icon_image')
+    def test_dict_command_fires_per_variant_when_both_drop(self, _icon, _tooltip, mock_cmd):
+        """Per-variant dict: each dropping variant fires its own command independently."""
+        self.app._prev_utilization = {'five_hour': 95.0, 'seven_day': 90.0}
+        data = {'five_hour': {'utilization': 5.0}, 'seven_day': {'utilization': 5.0}}
+        self.app.cache = MagicMock()
+        self.app.cache.update.return_value = UpdateResult(data=data)
+
+        self.app.update()
+
+        self.assertEqual(mock_cmd.call_count, 2)
+        executed_commands = {call[0][0][0] for call in mock_cmd.call_args_list}
+        self.assertEqual(executed_commands, {'echo 5h', 'echo 7d'})
+
+
 class TestThresholdCommand(unittest.TestCase):
     """Tests for on_threshold_command execution during threshold alerts."""
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -603,6 +603,50 @@ class TestSettingsValidation(unittest.TestCase):
         self.assertNotIn('on_threshold_command', result)
         mock.windll.user32.MessageBoxW.assert_called_once()
 
+    # Per-variant dict form
+
+    def test_on_reset_command_dict_string_values_normalized(self):
+        """Dict with string values is normalized to lists per variant."""
+        result, mock = self._run_validate({'on_reset_command': {'five_hour': 'echo ping', 'seven_day': 'echo weekly'}})
+        self.assertEqual(result['on_reset_command'], {'five_hour': ['echo ping'], 'seven_day': ['echo weekly']})
+        mock.windll.user32.MessageBoxW.assert_not_called()
+
+    def test_on_reset_command_dict_list_values_pass_through(self):
+        """Dict with list values passes through unchanged."""
+        result, mock = self._run_validate({'on_reset_command': {'five_hour': ['cmd1', 'cmd2']}})
+        self.assertEqual(result['on_reset_command'], {'five_hour': ['cmd1', 'cmd2']})
+        mock.windll.user32.MessageBoxW.assert_not_called()
+
+    def test_on_reset_command_dict_mixed_string_and_list_values(self):
+        """Dict mixing string and list values is normalized correctly."""
+        result, mock = self._run_validate({'on_reset_command': {'five_hour': 'echo ping', 'seven_day': ['cmd1', 'cmd2']}})
+        self.assertEqual(result['on_reset_command'], {'five_hour': ['echo ping'], 'seven_day': ['cmd1', 'cmd2']})
+        mock.windll.user32.MessageBoxW.assert_not_called()
+
+    def test_on_reset_command_empty_dict_valid(self):
+        """Empty dict is valid (no variant has a command configured)."""
+        result, mock = self._run_validate({'on_reset_command': {}})
+        self.assertEqual(result['on_reset_command'], {})
+        mock.windll.user32.MessageBoxW.assert_not_called()
+
+    def test_on_reset_command_dict_non_string_value_dropped(self):
+        """Dict with a non-string, non-list variant value is dropped."""
+        result, mock = self._run_validate({'on_reset_command': {'five_hour': 42}})
+        self.assertNotIn('on_reset_command', result)
+        mock.windll.user32.MessageBoxW.assert_called_once()
+
+    def test_on_reset_command_dict_list_with_non_string_item_dropped(self):
+        """Dict with a list containing a non-string item is dropped."""
+        result, mock = self._run_validate({'on_reset_command': {'five_hour': ['echo', 99]}})
+        self.assertNotIn('on_reset_command', result)
+        mock.windll.user32.MessageBoxW.assert_called_once()
+
+    def test_on_threshold_command_dict_string_values_normalized(self):
+        """Dict form also works for on_threshold_command."""
+        result, mock = self._run_validate({'on_threshold_command': {'five_hour': 'echo threshold', 'seven_day': ['cmd1']}})
+        self.assertEqual(result['on_threshold_command'], {'five_hour': ['echo threshold'], 'seven_day': ['cmd1']})
+        mock.windll.user32.MessageBoxW.assert_not_called()
+
     def _run_validate(self, data: dict) -> tuple[dict, MagicMock]:
         """Run _validate with mocked ctypes and return (result, mock_ctypes)."""
         mock_ctypes = MagicMock()

--- a/usage_monitor_for_claude/app.py
+++ b/usage_monitor_for_claude/app.py
@@ -36,6 +36,28 @@ from .tray_icon import create_icon_image, create_status_image, taskbar_uses_ligh
 __all__ = ['UsageMonitorForClaude', 'crash_log']
 
 
+def _resolve_commands(setting: list[str] | dict[str, list[str]], variant: str) -> list[str]:
+    """Return the command list for *variant* from *setting*.
+
+    Parameters
+    ----------
+    setting : list[str] | dict[str, list[str]]
+        Flat list of commands (fires for every variant) or a per-variant
+        mapping (fires only for matching variants).
+    variant : str
+        The quota variant key to look up (e.g. ``'five_hour'``).
+
+    Returns
+    -------
+    list[str]
+        Commands to run, or an empty list when no command is configured
+        for this variant.
+    """
+    if isinstance(setting, dict):
+        return setting.get(variant, [])
+    return setting
+
+
 def _future_iso(**kwargs: float) -> str:
     """Return an ISO 8601 timestamp offset from now by the given timedelta kwargs."""
     return (datetime.now(timezone.utc) + timedelta(**kwargs)).isoformat()
@@ -122,7 +144,7 @@ class UsageMonitorForClaude:
         webbrowser.open(PROJECT_URL)
 
     def on_test_reset_5h(self, icon: Any = None, item: Any = None) -> None:
-        run_event_command(ON_RESET_COMMAND, {
+        run_event_command(_resolve_commands(ON_RESET_COMMAND, 'five_hour'), {
             'USAGE_MONITOR_EVENT': 'reset',
             'USAGE_MONITOR_VARIANT': 'five_hour',
             'USAGE_MONITOR_UTILIZATION': '0',
@@ -135,7 +157,7 @@ class UsageMonitorForClaude:
         })
 
     def on_test_reset_7d(self, icon: Any = None, item: Any = None) -> None:
-        run_event_command(ON_RESET_COMMAND, {
+        run_event_command(_resolve_commands(ON_RESET_COMMAND, 'seven_day'), {
             'USAGE_MONITOR_EVENT': 'reset',
             'USAGE_MONITOR_VARIANT': 'seven_day',
             'USAGE_MONITOR_UTILIZATION': '0',
@@ -148,7 +170,7 @@ class UsageMonitorForClaude:
         })
 
     def on_test_threshold_5h(self, icon: Any = None, item: Any = None) -> None:
-        run_event_command(ON_THRESHOLD_COMMAND, {
+        run_event_command(_resolve_commands(ON_THRESHOLD_COMMAND, 'five_hour'), {
             'USAGE_MONITOR_EVENT': 'threshold',
             'USAGE_MONITOR_VARIANT': 'five_hour',
             'USAGE_MONITOR_UTILIZATION': '82',
@@ -159,7 +181,7 @@ class UsageMonitorForClaude:
         })
 
     def on_test_threshold_7d(self, icon: Any = None, item: Any = None) -> None:
-        run_event_command(ON_THRESHOLD_COMMAND, {
+        run_event_command(_resolve_commands(ON_THRESHOLD_COMMAND, 'seven_day'), {
             'USAGE_MONITOR_EVENT': 'threshold',
             'USAGE_MONITOR_VARIANT': 'seven_day',
             'USAGE_MONITOR_UTILIZATION': '81',
@@ -431,12 +453,13 @@ class UsageMonitorForClaude:
         self, variant: str, pct: float, prev_pct: float, *, data: dict[str, Any], entry: dict[str, Any],
     ) -> None:
         """Run the user-configured reset command if set."""
-        if not ON_RESET_COMMAND:
+        commands = _resolve_commands(ON_RESET_COMMAND, variant)
+        if not commands:
             return
 
         pct_5h = (data.get('five_hour') or {}).get('utilization', 0) or 0
         pct_7d = (data.get('seven_day') or {}).get('utilization', 0) or 0
-        run_event_command(ON_RESET_COMMAND, {
+        run_event_command(commands, {
             'USAGE_MONITOR_EVENT': 'reset',
             'USAGE_MONITOR_VARIANT': variant,
             'USAGE_MONITOR_UTILIZATION': str(round(pct)),
@@ -460,7 +483,10 @@ class UsageMonitorForClaude:
         commands.  Notifications still fire - commands react to *events*,
         not *state*.
         """
-        if not ON_THRESHOLD_COMMAND or not self._first_update_done:
+        if not self._first_update_done:
+            return
+        commands = _resolve_commands(ON_THRESHOLD_COMMAND, variant)
+        if not commands:
             return
 
         env_vars = {
@@ -477,7 +503,7 @@ class UsageMonitorForClaude:
         if extra_limit:
             env_vars['USAGE_MONITOR_EXTRA_LIMIT'] = extra_limit
 
-        run_event_command(ON_THRESHOLD_COMMAND, env_vars)
+        run_event_command(commands, env_vars)
 
     # Polling
 

--- a/usage_monitor_for_claude/settings.py
+++ b/usage_monitor_for_claude/settings.py
@@ -155,8 +155,33 @@ def _validate(data: dict, path: Path) -> dict:
                 if any(not isinstance(item, str) for item in value):
                     errors.append(f'  {key}: all items must be strings')
                     drop.append(key)
+            elif isinstance(value, dict):
+                normalized: dict[str, list[str]] = {}
+                valid = True
+                for variant_key, variant_cmds in value.items():
+                    if not isinstance(variant_key, str) or not variant_key:
+                        errors.append(f'  {key}: variant keys must be non-empty strings')
+                        drop.append(key)
+                        valid = False
+                        break
+                    if isinstance(variant_cmds, str):
+                        normalized[variant_key] = [variant_cmds]
+                    elif isinstance(variant_cmds, list):
+                        if any(not isinstance(item, str) for item in variant_cmds):
+                            errors.append(f'  {key}.{variant_key}: all items must be strings')
+                            drop.append(key)
+                            valid = False
+                            break
+                        normalized[variant_key] = variant_cmds
+                    else:
+                        errors.append(f'  {key}.{variant_key}: expected a string or array of strings, got {type(variant_cmds).__name__}')
+                        drop.append(key)
+                        valid = False
+                        break
+                if valid:
+                    data[key] = normalized
             else:
-                errors.append(f'  {key}: expected a string or array of strings, got {type(value).__name__}')
+                errors.append(f'  {key}: expected a string, array of strings, or object, got {type(value).__name__}')
                 drop.append(key)
 
         elif key in _BOOL_KEYS:
@@ -314,8 +339,8 @@ CURRENCY_SYMBOL: str = _S.get('currency_symbol', _SYSTEM_CURRENCY_SYMBOL)
 LANGUAGE: str = _S.get('language', '')
 
 # Event commands
-ON_RESET_COMMAND: list[str] = _S.get('on_reset_command', [])
-ON_THRESHOLD_COMMAND: list[str] = _S.get('on_threshold_command', [])
+ON_RESET_COMMAND: list[str] | dict[str, list[str]] = _S.get('on_reset_command', [])
+ON_THRESHOLD_COMMAND: list[str] | dict[str, list[str]] = _S.get('on_threshold_command', [])
 
 _ALERT_THRESHOLDS: dict[str, list[float]] = {
     'five_hour': [50, 80, 95],


### PR DESCRIPTION
Closes #34

## What this adds

`on_reset_command` and `on_threshold_command` now accept an **object keyed by quota variant** in addition to the existing string and array forms:

```json
{
  "on_reset_command": {
    "five_hour": "claude -p \"ok\" --tools \"\" --no-session-persistence --system-prompt \"Reply with only: ok\" --output-format text",
    "seven_day": "echo weekly reset"
  }
}
```

When a dict is provided, a command fires **only** for the matching variant. Variants not listed are silently ignored. Each variant's value can be a string (normalized to a single-element list) or an array of strings.

The existing string and array forms are fully backward-compatible.

## Motivation - quota trigger pattern

This enables a natural "quota trigger" pattern: fire a minimal `claude -p "ok"` ping the instant the 5h session resets so the next cooldown window starts immediately. Without this, users needed either a separate Task Scheduler job (blind 5h clock) or a wrapper PowerShell script checking `$env:USAGE_MONITOR_VARIANT`. The app already does idle-aware, reset-aligned polling - this makes it the right place to own this trigger.

## Changes

| File | Change |
|---|---|
| `usage_monitor_for_claude/settings.py` | `_validate()` accepts `dict[str, str \| list[str]]` for command keys; type annotations updated |
| `usage_monitor_for_claude/app.py` | `_resolve_commands()` helper; `_run_reset_command`, `_run_threshold_command`, and all four test-command handlers updated |
| `docs/event-commands.md` | Documents the object syntax; adds "Quota trigger" example |
| `tests/test_settings.py` | 7 new tests covering dict validation (string normalization, list passthrough, mixed, empty, invalid types) |
| `tests/test_app.py` | 3 new tests: matching variant fires, non-matching variant silent, both variants fire independently |
| `CHANGELOG.md` | Entry under `[Unreleased] > Added` |

## Tests

```
Ran 151 tests in 0.137s - OK
```
(5 pre-existing failures in `test_app.TestExtraUsageAlerts` due to French locale spacing `82 %` vs `82%` - not introduced by this PR)