### PR TITLE
fix: skip quota fields with null resets_at from popup display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Quota fields with a `null` reset time (e.g. `seven_day_omelette`) introduced by a recent API change are no longer shown in the popup
 - Usage bars are now always shown in red when they reach 100%, regardless of the time marker position
 
 [Show all code changes](https://github.com/jens-duttke/usage-monitor-for-claude/compare/v1.14.0...HEAD)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -223,6 +223,12 @@ class TestExpandPopupFields(unittest.TestCase):
         result = expand_popup_fields(['*'], usage)
         self.assertEqual(result, ['five_hour'])
 
+    def test_null_resets_at_skipped(self):
+        """Fields with None resets_at are skipped even when utilization is present."""
+        usage = {'five_hour': {'utilization': 10, 'resets_at': ''}, 'seven_day_omelette': {'utilization': 0.0, 'resets_at': None}}
+        result = expand_popup_fields(['*'], usage)
+        self.assertEqual(result, ['five_hour'])
+
     def test_missing_fields_skipped(self):
         """Explicitly listed fields missing from API are skipped."""
         usage = self._usage(five_hour=10)

--- a/usage_monitor_for_claude/formatting.py
+++ b/usage_monitor_for_claude/formatting.py
@@ -170,6 +170,7 @@ def expand_popup_fields(popup_fields: list[str], usage_data: dict[str, Any]) -> 
         key for key, value in usage_data.items()
         if isinstance(value, dict) and 'utilization' in value and 'resets_at' in value
         and value.get('utilization') is not None
+        and value.get('resets_at') is not None
     }
 
     result: list[str] = []


### PR DESCRIPTION
 ## Summary

  - Anthropic recently added new fields to the usage API (e.g. `seven_day_omelette`) that have `utilization` set but
  `resets_at` as `null`
  - These fields passed the existing filter in `expand_popup_fields` and appeared in the popup as "Weekly (Omelette)"
  - Added a `resets_at is not None` check to exclude fields that have no reset time, consistent with the existing
  `utilization is not None` check

  ## Test plan

  - [x] Added `test_null_resets_at_skipped` unit test covering the `seven_day_omelette` case (`utilization=0.0`,
  `resets_at=None`)
  - [x] All 125 tests in `test_formatting.py` pass
  - [x] Verified with a built EXE that "Weekly (Omelette)" no longer appears in the popup