### PR TITLE
fix: correct popup position on high-DPI and multi-monitor setups

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,11 +9,10 @@ Prioritize readability and auditability - users handle credentials and must be a
 
 ## Popup Window & DPI
 - The popup uses pywebview with a WinForms host window and Edge WebView2
-- pywebview's `resize()` expects **physical pixels** (it calls `SetWindowPos` directly without DPI scaling)
-- pywebview's `move()` expects **logical pixels** (it scales to physical internally)
-- `SystemParametersInfoW(SPI_GETWORKAREA)` returns **physical pixels** (process is Per-Monitor DPI Aware V2)
-- `_tray_position()` returns **logical coordinates** - never change this to physical
-- Never replace `resize()`/`move()` with direct `SetWindowPos` calls - the mixed coordinate spaces (physical size, logical position) make this error-prone
+- pywebview 6.x `resize()` **and** `move()` both expect **logical pixels** (pywebview applies DPI scaling internally for both)
+- `_tray_position()` still receives physical pixel dimensions (needed to calculate position against Win32 physical coordinates) and returns **logical coordinates** for `move()` - never change this to physical
+- `_tray_position()` uses `Shell_TrayWnd` + `MonitorFromWindow` + `GetMonitorInfoW` to find the monitor that owns the taskbar, then compares `work.left > mon.left` (not `> 0`) to detect a left-side taskbar - this correctly handles multi-monitor layouts where the primary monitor is not at virtual x=0
+- Never replace `resize()`/`move()` with direct `SetWindowPos` calls - pywebview's internal scaling means raw Win32 calls would fight with pywebview's coordinate handling
 - The taskbar icon is hidden via Win32 extended styles (`WS_EX_TOOLWINDOW` + remove `WS_EX_APPWINDOW`). Do **not** use WinForms `ShowInTaskbar = False` - it recreates the native window handle, which crashes WebView2 from background threads
 
 ## Quota Fields

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,7 +12,7 @@ from tempfile import TemporaryDirectory
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from usage_monitor_for_claude.api import API_URL_USAGE, CLAUDE_CONFIG_DIR, CLAUDE_CREDENTIALS, _extract_server_message, _parse_retry_after, fetch_usage, read_access_token
+from usage_monitor_for_claude.api import API_URL_USAGE, _extract_server_message, _parse_retry_after, fetch_usage, read_access_token
 from usage_monitor_for_claude.i18n import LOCALE_DIR
 
 EN = json.loads((LOCALE_DIR / 'en.json').read_text(encoding='utf-8'))

--- a/tests/test_popup.py
+++ b/tests/test_popup.py
@@ -7,11 +7,12 @@ and _init_config.
 """
 from __future__ import annotations
 
+import ctypes
 import unittest
 from unittest.mock import MagicMock, patch
 
 from usage_monitor_for_claude.cache import CacheSnapshot
-from usage_monitor_for_claude.popup import UsagePopup, _BASELINE_DPI, _init_config, _snapshot_to_dict, _usage_entries
+from usage_monitor_for_claude.popup import UsagePopup, _BASELINE_DPI, _MONITORINFO, _init_config, _snapshot_to_dict, _usage_entries
 
 
 def _snap(
@@ -520,22 +521,27 @@ class TestTrayPosition(unittest.TestCase):
     It returns logical coordinates suitable for pywebview's move().
     """
 
-    def _call(self, work_left, work_top, work_right, work_bottom, dpi, physical_width, physical_height):
+    def _call(self, work_left, work_top, work_right, work_bottom, dpi, physical_width, physical_height,
+              mon_left=0, mon_top=0):
         """Call _tray_position without constructing a full UsagePopup."""
         popup = object.__new__(UsagePopup)
         popup._popup_hwnd = 12345
 
-        def set_rect(_code, _size, rect_ptr, _flags):
-            import ctypes
-            import ctypes.wintypes
-            rect = ctypes.cast(rect_ptr, ctypes.POINTER(ctypes.wintypes.RECT)).contents
-            rect.left = work_left
-            rect.top = work_top
-            rect.right = work_right
-            rect.bottom = work_bottom
-            return 1
+        def fill_mon_info(_hmon, ptr):
+            info = ctypes.cast(ptr, ctypes.POINTER(_MONITORINFO)).contents
+            info.cbSize = ctypes.sizeof(_MONITORINFO)
+            info.rcMonitor.left = mon_left
+            info.rcMonitor.top = mon_top
+            info.rcMonitor.right = work_right
+            info.rcMonitor.bottom = work_bottom
+            info.rcWork.left = work_left
+            info.rcWork.top = work_top
+            info.rcWork.right = work_right
+            info.rcWork.bottom = work_bottom
 
-        with patch('ctypes.windll.user32.SystemParametersInfoW', side_effect=set_rect), \
+        with patch('ctypes.windll.user32.FindWindowW', return_value=99999), \
+             patch('ctypes.windll.user32.MonitorFromWindow', return_value=11111), \
+             patch('ctypes.windll.user32.GetMonitorInfoW', side_effect=fill_mon_info), \
              patch('ctypes.windll.user32.GetDpiForWindow', return_value=dpi):
             return popup._tray_position(physical_width, physical_height)
 
@@ -594,6 +600,19 @@ class TestTrayPosition(unittest.TestCase):
         self.assertLessEqual(physical_x + pw, work_right)
         self.assertLessEqual(physical_y + ph, work_bottom)
 
+    def test_taskbar_on_bottom_when_monitor_offset_left(self):
+        """Popup goes to bottom-right even when the primary monitor is not at virtual x=0.
+
+        Regression: the old code used ``work_area.left > 0`` which fired incorrectly
+        whenever secondary monitors were positioned to the left of the primary,
+        causing the popup to land at the left edge instead of the bottom-right corner.
+        """
+        # Primary monitor starts at virtual x=1920 (another monitor sits to its left).
+        # Taskbar is at the bottom: work_left == mon_left, so NOT a left-side taskbar.
+        x, y = self._call(1920, 0, 3840, 1040, _BASELINE_DPI, 340, 400, mon_left=1920)
+        self.assertEqual(x, 3840 - 340 - 12)
+        self.assertEqual(y, 1040 - 400 - 12)
+
 
 # ---------------------------------------------------------------------------
 # _resize_and_position
@@ -611,18 +630,22 @@ class TestResizeAndPosition(unittest.TestCase):
         mock_window = MagicMock()
         popup._window = mock_window
 
-        def set_rect(_code, _size, rect_ptr, _flags):
-            import ctypes
-            import ctypes.wintypes
-            rect = ctypes.cast(rect_ptr, ctypes.POINTER(ctypes.wintypes.RECT)).contents
-            rect.left = 0
-            rect.top = 0
-            rect.right = 1920
-            rect.bottom = 1040
-            return 1
+        def fill_mon_info(_hmon, ptr):
+            info = ctypes.cast(ptr, ctypes.POINTER(_MONITORINFO)).contents
+            info.cbSize = ctypes.sizeof(_MONITORINFO)
+            info.rcMonitor.left = 0
+            info.rcMonitor.top = 0
+            info.rcMonitor.right = 1920
+            info.rcMonitor.bottom = 1080
+            info.rcWork.left = 0
+            info.rcWork.top = 0
+            info.rcWork.right = 1920
+            info.rcWork.bottom = 1040
 
         with patch('ctypes.windll.user32.GetDpiForWindow', return_value=dpi), \
-             patch('ctypes.windll.user32.SystemParametersInfoW', side_effect=set_rect):
+             patch('ctypes.windll.user32.FindWindowW', return_value=99999), \
+             patch('ctypes.windll.user32.MonitorFromWindow', return_value=11111), \
+             patch('ctypes.windll.user32.GetMonitorInfoW', side_effect=fill_mon_info):
             popup._resize_and_position(css_height)
 
         return mock_window
@@ -633,14 +656,14 @@ class TestResizeAndPosition(unittest.TestCase):
         mock.resize.assert_called_once_with(340, 500)
 
     def test_resize_at_125_percent(self):
-        """At 125% DPI, resize multiplies by scale factor for physical pixels."""
+        """At 125% DPI, resize receives logical pixels; pywebview scales internally."""
         mock = self._call(500, 120)
-        mock.resize.assert_called_once_with(int(340 * 1.25), int(500 * 1.25))
+        mock.resize.assert_called_once_with(340, 500)
 
     def test_resize_at_150_percent(self):
-        """At 150% DPI, resize multiplies by scale factor for physical pixels."""
+        """At 150% DPI, resize receives logical pixels; pywebview scales internally."""
         mock = self._call(500, 144)
-        mock.resize.assert_called_once_with(int(340 * 1.5), int(500 * 1.5))
+        mock.resize.assert_called_once_with(340, 500)
 
     def test_move_receives_logical_coordinates(self):
         """move() receives logical coordinates regardless of DPI."""
@@ -657,11 +680,9 @@ class TestResizeAndPosition(unittest.TestCase):
         mock = self._call(500, dpi)
         resize_w, resize_h = mock.resize.call_args[0]
         move_x, move_y = mock.move.call_args[0]
-        # move() scales logical to physical internally
-        physical_x = move_x * scale
-        physical_y = move_y * scale
-        self.assertLessEqual(physical_x + resize_w, 1920)
-        self.assertLessEqual(physical_y + resize_h, 1040)
+        # pywebview 6.x scales both resize() and move() to physical internally
+        self.assertLessEqual((move_x + resize_w) * scale, 1920)
+        self.assertLessEqual((move_y + resize_h) * scale, 1040)
 
     def test_falls_back_to_system_dpi_when_window_dpi_unavailable(self):
         """When GetDpiForWindow returns 0, GetDpiForSystem is used as fallback."""
@@ -672,23 +693,27 @@ class TestResizeAndPosition(unittest.TestCase):
         mock_window = MagicMock()
         popup._window = mock_window
 
-        def set_rect(_code, _size, rect_ptr, _flags):
-            import ctypes
-            import ctypes.wintypes
-            rect = ctypes.cast(rect_ptr, ctypes.POINTER(ctypes.wintypes.RECT)).contents
-            rect.left = 0
-            rect.top = 0
-            rect.right = 1920
-            rect.bottom = 1040
-            return 1
+        def fill_mon_info(_hmon, ptr):
+            info = ctypes.cast(ptr, ctypes.POINTER(_MONITORINFO)).contents
+            info.cbSize = ctypes.sizeof(_MONITORINFO)
+            info.rcMonitor.left = 0
+            info.rcMonitor.top = 0
+            info.rcMonitor.right = 1920
+            info.rcMonitor.bottom = 1080
+            info.rcWork.left = 0
+            info.rcWork.top = 0
+            info.rcWork.right = 1920
+            info.rcWork.bottom = 1040
 
         with patch('ctypes.windll.user32.GetDpiForWindow', return_value=0), \
              patch('ctypes.windll.user32.GetDpiForSystem', return_value=144) as mock_sys_dpi, \
-             patch('ctypes.windll.user32.SystemParametersInfoW', side_effect=set_rect):
+             patch('ctypes.windll.user32.FindWindowW', return_value=99999), \
+             patch('ctypes.windll.user32.MonitorFromWindow', return_value=11111), \
+             patch('ctypes.windll.user32.GetMonitorInfoW', side_effect=fill_mon_info):
             popup._resize_and_position(500)
 
         mock_sys_dpi.assert_called()
-        mock_window.resize.assert_called_once_with(int(340 * 1.5), int(500 * 1.5))
+        mock_window.resize.assert_called_once_with(340, 500)
 
 
 if __name__ == '__main__':

--- a/tests/test_verbose.py
+++ b/tests/test_verbose.py
@@ -7,7 +7,6 @@ Unit tests for the --verbose diagnostic helpers.
 from __future__ import annotations
 
 import io
-import sys
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/usage_monitor_for_claude/popup.py
+++ b/usage_monitor_for_claude/popup.py
@@ -33,6 +33,16 @@ _WS_EX_TOOLWINDOW = 0x00000080
 _WS_EX_LAYERED = 0x00080000
 _LWA_ALPHA = 0x00000002
 
+
+class _MONITORINFO(ctypes.Structure):
+    _fields_ = [
+        ('cbSize', ctypes.wintypes.DWORD),
+        ('rcMonitor', ctypes.wintypes.RECT),
+        ('rcWork', ctypes.wintypes.RECT),
+        ('dwFlags', ctypes.wintypes.DWORD),
+    ]
+
+
 __all__ = ['UsagePopup']
 
 if TYPE_CHECKING:
@@ -428,23 +438,29 @@ class UsagePopup:
             Logical (x, y) coordinates.  Callers that need physical pixels
             must multiply by the DPI scale factor.
         """
-        work_area = ctypes.wintypes.RECT()
-        ctypes.windll.user32.SystemParametersInfoW(0x0030, 0, ctypes.byref(work_area), 0)
+        tray_hwnd = ctypes.windll.user32.FindWindowW('Shell_TrayWnd', None)
+        hmon = ctypes.windll.user32.MonitorFromWindow(tray_hwnd, 2)  # MONITOR_DEFAULTTONEAREST
+
+        mon_info = _MONITORINFO()
+        mon_info.cbSize = ctypes.sizeof(_MONITORINFO)
+        ctypes.windll.user32.GetMonitorInfoW(hmon, ctypes.byref(mon_info))
+        mon = mon_info.rcMonitor
+        work = mon_info.rcWork
 
         dpi = ctypes.windll.user32.GetDpiForWindow(self._popup_hwnd) or ctypes.windll.user32.GetDpiForSystem()
         scale = dpi / _BASELINE_DPI
 
         margin = 12
 
-        if work_area.left > 0:
-            x = work_area.left + margin
+        if work.left > mon.left:    # left-side taskbar
+            x = work.left + margin
         else:
-            x = work_area.right - physical_width - margin
+            x = work.right - physical_width - margin
 
-        if work_area.top > 0:
-            y = work_area.top + margin
+        if work.top > mon.top:      # top taskbar
+            y = work.top + margin
         else:
-            y = work_area.bottom - physical_height - margin
+            y = work.bottom - physical_height - margin
 
         return int(x / scale), int(y / scale)
 
@@ -454,16 +470,16 @@ class UsagePopup:
         The first call happens while the window is still transparent
         (opacity 0), so separate resize/move calls cause no visible jump.
 
-        pywebview's ``resize()`` calls ``SetWindowPos`` directly without
-        DPI scaling, so it expects physical pixels.  The *height* from JS
-        ``ResizeObserver`` is in CSS pixels, so we multiply by the window's
-        current DPI factor.  ``move()`` scales internally, and
-        ``_tray_position`` already accounts for that.
+        pywebview 6.x ``resize()`` applies DPI scaling internally (consistent
+        with ``move()``), so both expect logical pixels.  Physical dimensions
+        are still computed for ``_tray_position``, which needs them to
+        calculate the correct logical position against the physical work-area
+        coordinates returned by Win32.
         """
         dpi = ctypes.windll.user32.GetDpiForWindow(self._popup_hwnd) or ctypes.windll.user32.GetDpiForSystem()
         scale = dpi / _BASELINE_DPI
         physical_width = int(self.WIDTH * scale)
         physical_height = int(height * scale)
-        self._window.resize(physical_width, physical_height)
+        self._window.resize(self.WIDTH, height)
         x, y = self._tray_position(physical_width, physical_height)
         self._window.move(x, y)


### PR DESCRIPTION
## Summary

  Two bugs combined to make the popup appear off-screen or at the wrong corner.

  **Bug 1 — Double DPI scaling in `resize()` (primary cause at 200% DPI)**
  `_resize_and_position()` pre-multiplied the window dimensions by the DPI scale factor before calling `resize()`. This was correct for older pywebview versions,
   but pywebview 6.x `resize()` now applies DPI scaling internally (consistent with `move()`). The result at 200% DPI: the popup was rendered at 4× its intended
  area, overflowing the right and bottom screen edges.

  **Bug 2 — Wrong taskbar-edge detection on multi-monitor setups**
  `_tray_position()` used `work_area.left > 0` to detect a left-side taskbar. This condition fires incorrectly whenever the primary monitor is not at virtual
  coordinate x=0 — i.e. whenever other monitors are positioned to the left of the primary. The popup would land at the left edge of the screen instead of the
  bottom-right corner where the taskbar actually is.

  **Fixes:**
  - `resize()` now receives logical pixels (`self.WIDTH, height`); pywebview handles DPI scaling.
  - `_tray_position()` now uses `Shell_TrayWnd` + `MonitorFromWindow` + `GetMonitorInfoW` to find the monitor that actually owns the taskbar, then compares
  `work.left > mon.left` instead of `> 0`.

  Tested on Windows 11, 3 monitors, 200% DPI (pywebview 6.2.1, Python 3.12).

  ## Workflow checklist

  - [x] Read [`.claude/CLAUDE.md`](../blob/main/.claude/CLAUDE.md) and followed the project conventions
  - [x] Ran the `/review` slash command on all staged changes (code, tests, documentation)
  - [x] Used `/commit-message` to generate the commit message(s)
  - [x] Ran the full test suite: `python -m unittest discover -s tests`

  ## User-facing changes

  Internal fix only — no changes to user-visible strings, configuration, or documented features.

  ## Notes for reviewers

  - `_MONITORINFO` ctypes struct added at module level (needed for `GetMonitorInfoW`; also imported by the test suite to fill mock responses).
  - `physical_width`/`physical_height` are still computed in `_resize_and_position()` — no longer passed to `resize()` but still needed by `_tray_position()` to
  calculate the correct logical corner position against Win32 physical coordinates.
  - `CLAUDE.md` updated to reflect the pywebview 6.x coordinate-space change.