### PR TITLE
feat: add hour dividers on the 5-hour session usage bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Windows may hide new tray icons by default. To keep the icon always visible:
 Each bar in the detail popup has up to four visual elements:
 
 1. **Blue fill** - how much of the limit you have used
-2. **Day dividers** - subtle gaps at local midnight boundaries, visually grouping usage into day segments (visible on the weekly bar)
+2. **Time dividers** - subtle gaps splitting the session bar into equal hour sections and marking local midnights on the weekly bars, visually grouping usage into hour and day segments
 3. **White vertical line** - how much *time* has passed in the current period. The fill turns **red** when it passes this marker, warning that you may hit the limit before the period resets.
 4. **Reset text** - when the limit resets, shown as a countdown with clock time
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -180,5 +180,5 @@ Override individual channels as RGBA arrays `[R, G, B, A]` (0-255). Unspecified 
 | `bar_bg` | `"#333333"` | Progress bar background |
 | `bar_fg` | `"#4a9eff"` | Progress bar fill |
 | `bar_fg_warn` | `"#e05050"` | Progress bar fill when usage outpaces elapsed time, error text |
-| `bar_divider` | `"#000c"` | Midnight divider on weekly progress bars |
+| `bar_divider` | `"#000c"` | Time dividers on progress bars (hour marks on the session bar, midnights on weekly bars) |
 | `bar_marker` | `"#fffc"` | Time-position marker on progress bars |

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -14,8 +14,8 @@ from unittest.mock import MagicMock, patch
 
 from usage_monitor_for_claude.formatting import (
     PERIOD_5H, PERIOD_7D,
-    elapsed_pct, expand_popup_fields, field_period, format_credits, format_tooltip,
-    midnight_positions, parse_field_name, popup_label, time_until, tooltip_label,
+    divider_positions, elapsed_pct, expand_popup_fields, field_period, format_credits,
+    format_tooltip, parse_field_name, popup_label, time_until, tooltip_label,
 )
 from usage_monitor_for_claude.i18n import LOCALE_DIR
 
@@ -412,13 +412,13 @@ class TestElapsedPct(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# midnight_positions
+# divider_positions
 # ---------------------------------------------------------------------------
 
-class TestMidnightPositions(unittest.TestCase):
-    """Tests for midnight_positions().
+class TestDividerPositions(unittest.TestCase):
+    """Tests for divider_positions().
 
-    Because midnight_positions converts to local time via astimezone(), tests
+    Because divider_positions converts to local time via astimezone(), tests
     construct inputs relative to the system timezone so results are predictable
     on any machine.
     """
@@ -430,68 +430,78 @@ class TestMidnightPositions(unittest.TestCase):
 
     def test_empty_resets_at(self):
         """Empty resets_at returns empty list."""
-        self.assertEqual(midnight_positions('', PERIOD_7D), [])
+        self.assertEqual(divider_positions('', PERIOD_7D), [])
 
     def test_zero_period(self):
         """period_seconds=0 returns empty list."""
-        self.assertEqual(midnight_positions('2025-01-15T12:00:00+00:00', 0), [])
+        self.assertEqual(divider_positions('2025-01-15T12:00:00+00:00', 0), [])
 
     def test_negative_period(self):
         """Negative period_seconds returns empty list."""
-        self.assertEqual(midnight_positions('2025-01-15T12:00:00+00:00', -100), [])
+        self.assertEqual(divider_positions('2025-01-15T12:00:00+00:00', -100), [])
 
     def test_invalid_iso_string(self):
         """Invalid ISO string returns empty list."""
-        self.assertEqual(midnight_positions('not-a-date', PERIOD_7D), [])
+        self.assertEqual(divider_positions('not-a-date', PERIOD_7D), [])
+        self.assertEqual(divider_positions('not-a-date', PERIOD_5H), [])
 
-    def test_5h_period_no_midnight(self):
-        """5h period within a single day has no midnight crossings."""
-        # Period: 10:00-15:00 local on the same day - no midnight
+    def test_5h_period_has_four_hour_dividers(self):
+        """5h period is split into five equal sections by four dividers."""
         reset_iso = self._local_to_utc_iso(datetime(2025, 1, 15, 15, 0, 0))
-        result = midnight_positions(reset_iso, PERIOD_5H)
-        self.assertEqual(result, [])
+        result = divider_positions(reset_iso, PERIOD_5H)
+        self.assertEqual(len(result), 4)
+        for pos, expected in zip(result, (0.2, 0.4, 0.6, 0.8)):
+            self.assertAlmostEqual(pos, expected, places=4)
+
+    def test_5h_dividers_independent_of_window_start(self):
+        """Sub-day dividers do not shift with the window's clock alignment."""
+        # Hour-aligned (15:00), mid-hour (15:30), and midnight-spanning (04:00) windows split identically
+        for reset_local in (datetime(2025, 1, 15, 15, 0, 0), datetime(2025, 1, 15, 15, 30, 0), datetime(2025, 1, 16, 4, 0, 0)):
+            result = divider_positions(self._local_to_utc_iso(reset_local), PERIOD_5H)
+            self.assertEqual(len(result), 4)
+            self.assertAlmostEqual(result[0], 0.2, places=4)
+
+    def test_other_subday_periods_have_no_dividers(self):
+        """Sub-day periods other than five hours are not subdivided."""
+        reset_iso = self._local_to_utc_iso(datetime(2025, 1, 15, 15, 0, 0))
+        for period_seconds in (3600, 3 * 3600, 23 * 3600):
+            self.assertEqual(divider_positions(reset_iso, period_seconds), [])
 
     def test_7d_period_has_seven_midnights(self):
         """7-day period from noon to noon has exactly 7 internal midnight boundaries."""
         # Period: Jan 15 12:00 to Jan 22 12:00 local - midnights on Jan 16-22
         reset_iso = self._local_to_utc_iso(datetime(2025, 1, 22, 12, 0, 0))
-        result = midnight_positions(reset_iso, PERIOD_7D)
+        result = divider_positions(reset_iso, PERIOD_7D)
         self.assertEqual(len(result), 7)
+
+    def test_exactly_one_day_period_uses_midnights(self):
+        """A period of exactly 24h subdivides at midnights, not hours."""
+        # Period: Jan 15 12:00 to Jan 16 12:00 local - single midnight at 0.5
+        reset_iso = self._local_to_utc_iso(datetime(2025, 1, 16, 12, 0, 0))
+        result = divider_positions(reset_iso, 24 * 3600)
+        self.assertEqual(len(result), 1)
+        self.assertAlmostEqual(result[0], 0.5, places=4)
 
     def test_positions_are_sorted_ascending(self):
         """Positions must be in ascending order."""
         reset_iso = self._local_to_utc_iso(datetime(2025, 1, 22, 12, 0, 0))
-        result = midnight_positions(reset_iso, PERIOD_7D)
+        result = divider_positions(reset_iso, PERIOD_7D)
         self.assertEqual(result, sorted(result))
 
     def test_positions_in_valid_range(self):
         """All positions must be in the range (0.0, 1.0) exclusive."""
         reset_iso = self._local_to_utc_iso(datetime(2025, 1, 22, 12, 0, 0))
-        result = midnight_positions(reset_iso, PERIOD_7D)
+        result = divider_positions(reset_iso, PERIOD_7D)
         for pos in result:
             self.assertGreater(pos, 0.0)
             self.assertLess(pos, 1.0)
 
-    def test_5h_period_spanning_midnight(self):
-        """5h period crossing local midnight has exactly one midnight position."""
-        # Period: 23:00-04:00 local, crosses one midnight
-        reset_iso = self._local_to_utc_iso(datetime(2025, 1, 16, 4, 0, 0))
-        result = midnight_positions(reset_iso, PERIOD_5H)
-        self.assertEqual(len(result), 1)
-
-    def test_5h_midnight_position_is_correct(self):
-        """Midnight position in a 5h period crossing midnight at the expected fraction."""
-        # Period: 23:00-04:00 local. Midnight is 1h into a 5h period = 0.2
-        reset_iso = self._local_to_utc_iso(datetime(2025, 1, 16, 4, 0, 0))
-        result = midnight_positions(reset_iso, PERIOD_5H)
-        self.assertEqual(len(result), 1)
-        self.assertAlmostEqual(result[0], 0.2, places=2)
-
     def test_near_zero_positions_filtered(self):
-        """Positions very close to 0.0 (< 0.003) are filtered out."""
-        # Period: 23:59:50-04:59:50 local. Midnight is 10s in = 10/18000 ≈ 0.00056, filtered.
-        reset_iso = self._local_to_utc_iso(datetime(2025, 1, 16, 4, 59, 50))
-        result = midnight_positions(reset_iso, PERIOD_5H)
+        """Midnight positions very close to 0.0 (< 0.003) are filtered out."""
+        # Period: Jan 15 23:59:50 to Jan 22 23:59:50 local. First midnight is 10s in ≈ 0.0000165, filtered.
+        reset_iso = self._local_to_utc_iso(datetime(2025, 1, 22, 23, 59, 50))
+        result = divider_positions(reset_iso, PERIOD_7D)
+        self.assertEqual(len(result), 6)
         for pos in result:
             self.assertGreater(pos, 0.003)
 
@@ -499,7 +509,7 @@ class TestMidnightPositions(unittest.TestCase):
         """First midnight in a 7d period starting at noon is at roughly 1/14 of the bar."""
         # Period: Jan 15 12:00 to Jan 22 12:00 local. First midnight is 12h into 168h = 1/14
         reset_iso = self._local_to_utc_iso(datetime(2025, 1, 22, 12, 0, 0))
-        result = midnight_positions(reset_iso, PERIOD_7D)
+        result = divider_positions(reset_iso, PERIOD_7D)
         self.assertGreater(len(result), 0)
         self.assertAlmostEqual(result[0], 12 / 168, places=2)
 

--- a/tests/test_popup.py
+++ b/tests/test_popup.py
@@ -193,8 +193,8 @@ class TestSnapshotToDict(unittest.TestCase):
 
     @patch('usage_monitor_for_claude.popup.elapsed_pct', return_value=None)
     @patch('usage_monitor_for_claude.popup.time_until', return_value='5h 0m')
-    @patch('usage_monitor_for_claude.popup.midnight_positions', return_value=[])
-    def test_usage_bar_fields(self, _mock_midnights, _mock_time_until, _mock_elapsed):
+    @patch('usage_monitor_for_claude.popup.divider_positions', return_value=[])
+    def test_usage_bar_fields(self, _mock_dividers, _mock_time_until, _mock_elapsed):
         """Each usage bar dict has all required fields with correct types."""
         usage = {'five_hour': {'utilization': 42, 'resets_at': '2026-01-01T05:00:00Z'}}
         result = _snapshot_to_dict(_snap(usage=usage), installations=[])
@@ -206,12 +206,12 @@ class TestSnapshotToDict(unittest.TestCase):
         self.assertFalse(bar['warn'])
         self.assertIsNone(bar['marker_rel'])
         self.assertEqual(bar['reset_text'], '5h 0m')
-        self.assertEqual(bar['midnights'], [])
+        self.assertEqual(bar['dividers'], [])
 
     @patch('usage_monitor_for_claude.popup.elapsed_pct', return_value=30.0)
     @patch('usage_monitor_for_claude.popup.time_until', return_value='3h 30m')
-    @patch('usage_monitor_for_claude.popup.midnight_positions', return_value=[0.5])
-    def test_warn_when_usage_ahead_of_time(self, _mock_midnights, _mock_time_until, _mock_elapsed):
+    @patch('usage_monitor_for_claude.popup.divider_positions', return_value=[0.5])
+    def test_warn_when_usage_ahead_of_time(self, _mock_dividers, _mock_time_until, _mock_elapsed):
         """Bar is marked warn when utilization exceeds elapsed percentage."""
         usage = {'five_hour': {'utilization': 60, 'resets_at': '2026-01-01T05:00:00Z'}}
         result = _snapshot_to_dict(_snap(usage=usage), installations=[])
@@ -222,8 +222,8 @@ class TestSnapshotToDict(unittest.TestCase):
 
     @patch('usage_monitor_for_claude.popup.elapsed_pct', return_value=80.0)
     @patch('usage_monitor_for_claude.popup.time_until', return_value='1h 0m')
-    @patch('usage_monitor_for_claude.popup.midnight_positions', return_value=[])
-    def test_no_warn_when_usage_behind_time(self, _mock_midnights, _mock_time_until, _mock_elapsed):
+    @patch('usage_monitor_for_claude.popup.divider_positions', return_value=[])
+    def test_no_warn_when_usage_behind_time(self, _mock_dividers, _mock_time_until, _mock_elapsed):
         """Bar is not warn when utilization is below elapsed percentage."""
         usage = {'five_hour': {'utilization': 40, 'resets_at': '2026-01-01T05:00:00Z'}}
         result = _snapshot_to_dict(_snap(usage=usage), installations=[])
@@ -233,8 +233,8 @@ class TestSnapshotToDict(unittest.TestCase):
 
     @patch('usage_monitor_for_claude.popup.elapsed_pct', return_value=50.0)
     @patch('usage_monitor_for_claude.popup.time_until', return_value='2h 30m')
-    @patch('usage_monitor_for_claude.popup.midnight_positions', return_value=[])
-    def test_no_warn_when_equal(self, _mock_midnights, _mock_time_until, _mock_elapsed):
+    @patch('usage_monitor_for_claude.popup.divider_positions', return_value=[])
+    def test_no_warn_when_equal(self, _mock_dividers, _mock_time_until, _mock_elapsed):
         """Exactly equal usage and elapsed is not a warning (strictly greater)."""
         usage = {'five_hour': {'utilization': 50, 'resets_at': '2026-01-01T05:00:00Z'}}
         result = _snapshot_to_dict(_snap(usage=usage), installations=[])
@@ -242,8 +242,8 @@ class TestSnapshotToDict(unittest.TestCase):
 
     @patch('usage_monitor_for_claude.popup.elapsed_pct', return_value=None)
     @patch('usage_monitor_for_claude.popup.time_until', return_value='')
-    @patch('usage_monitor_for_claude.popup.midnight_positions', return_value=[])
-    def test_warn_at_100_without_time_period(self, _mock_midnights, _mock_time_until, _mock_elapsed):
+    @patch('usage_monitor_for_claude.popup.divider_positions', return_value=[])
+    def test_warn_at_100_without_time_period(self, _mock_dividers, _mock_time_until, _mock_elapsed):
         """Bar at 100% is warn even when no time period (time_pct is None)."""
         usage = {'five_hour': {'utilization': 100, 'resets_at': ''}}
         result = _snapshot_to_dict(_snap(usage=usage), installations=[])
@@ -251,8 +251,8 @@ class TestSnapshotToDict(unittest.TestCase):
 
     @patch('usage_monitor_for_claude.popup.elapsed_pct', return_value=100.0)
     @patch('usage_monitor_for_claude.popup.time_until', return_value='')
-    @patch('usage_monitor_for_claude.popup.midnight_positions', return_value=[])
-    def test_warn_at_100_when_time_also_100(self, _mock_midnights, _mock_time_until, _mock_elapsed):
+    @patch('usage_monitor_for_claude.popup.divider_positions', return_value=[])
+    def test_warn_at_100_when_time_also_100(self, _mock_dividers, _mock_time_until, _mock_elapsed):
         """Bar at 100% is warn even when elapsed time is also 100% (strict > would miss this)."""
         usage = {'five_hour': {'utilization': 100, 'resets_at': '2026-01-01T05:00:00Z'}}
         result = _snapshot_to_dict(_snap(usage=usage), installations=[])
@@ -260,8 +260,8 @@ class TestSnapshotToDict(unittest.TestCase):
 
     @patch('usage_monitor_for_claude.popup.elapsed_pct', return_value=None)
     @patch('usage_monitor_for_claude.popup.time_until', return_value='')
-    @patch('usage_monitor_for_claude.popup.midnight_positions', return_value=[])
-    def test_fill_pct_clamped_to_0_1(self, _mock_midnights, _mock_time_until, _mock_elapsed):
+    @patch('usage_monitor_for_claude.popup.divider_positions', return_value=[])
+    def test_fill_pct_clamped_to_0_1(self, _mock_dividers, _mock_time_until, _mock_elapsed):
         """Fill percentage is clamped between 0.0 and 1.0, and over-quota is always warn."""
         usage = {'five_hour': {'utilization': 150, 'resets_at': '2026-01-01T05:00:00Z'}}
         result = _snapshot_to_dict(_snap(usage=usage), installations=[])
@@ -270,8 +270,8 @@ class TestSnapshotToDict(unittest.TestCase):
 
     @patch('usage_monitor_for_claude.popup.elapsed_pct', return_value=None)
     @patch('usage_monitor_for_claude.popup.time_until', return_value='')
-    @patch('usage_monitor_for_claude.popup.midnight_positions', return_value=[])
-    def test_zero_utilization(self, _mock_midnights, _mock_time_until, _mock_elapsed):
+    @patch('usage_monitor_for_claude.popup.divider_positions', return_value=[])
+    def test_zero_utilization(self, _mock_dividers, _mock_time_until, _mock_elapsed):
         """Zero utilization produces 0% text and 0.0 fill."""
         usage = {'five_hour': {'utilization': 0, 'resets_at': '2026-01-01T05:00:00Z'}}
         result = _snapshot_to_dict(_snap(usage=usage), installations=[])
@@ -282,8 +282,8 @@ class TestSnapshotToDict(unittest.TestCase):
 
     @patch('usage_monitor_for_claude.popup.elapsed_pct', return_value=None)
     @patch('usage_monitor_for_claude.popup.time_until', return_value='')
-    @patch('usage_monitor_for_claude.popup.midnight_positions', return_value=[])
-    def test_multiple_usage_entries(self, _mock_midnights, _mock_time_until, _mock_elapsed):
+    @patch('usage_monitor_for_claude.popup.divider_positions', return_value=[])
+    def test_multiple_usage_entries(self, _mock_dividers, _mock_time_until, _mock_elapsed):
         """Multiple usage types each produce a bar entry."""
         usage = {
             'five_hour': {'utilization': 10, 'resets_at': '2026-01-01T05:00:00Z'},
@@ -298,8 +298,8 @@ class TestSnapshotToDict(unittest.TestCase):
     @patch('usage_monitor_for_claude.popup.POPUP_FIELDS', ['typo_field', 'seven_day'])
     @patch('usage_monitor_for_claude.popup.elapsed_pct', return_value=None)
     @patch('usage_monitor_for_claude.popup.time_until', return_value='')
-    @patch('usage_monitor_for_claude.popup.midnight_positions', return_value=[])
-    def test_misspelled_popup_field_skipped_in_dict(self, _mock_mid, _mock_tu, _mock_ep):
+    @patch('usage_monitor_for_claude.popup.divider_positions', return_value=[])
+    def test_misspelled_popup_field_skipped_in_dict(self, _mock_div, _mock_tu, _mock_ep):
         """Misspelled popup_fields entry produces no bar, valid one shown."""
         usage = {
             'five_hour': {'utilization': 42, 'resets_at': '2026-01-01T05:00:00Z'},
@@ -317,8 +317,8 @@ class TestSnapshotToDict(unittest.TestCase):
 
     @patch('usage_monitor_for_claude.popup.elapsed_pct', return_value=None)
     @patch('usage_monitor_for_claude.popup.time_until', return_value='')
-    @patch('usage_monitor_for_claude.popup.midnight_positions', return_value=[])
-    def test_non_dict_values_in_response_ignored(self, _mock_mid, _mock_tu, _mock_ep):
+    @patch('usage_monitor_for_claude.popup.divider_positions', return_value=[])
+    def test_non_dict_values_in_response_ignored(self, _mock_div, _mock_tu, _mock_ep):
         """Non-dict values in the API response are not shown as bars."""
         usage = {
             'error': 'temporary',
@@ -412,8 +412,8 @@ class TestSnapshotToDict(unittest.TestCase):
 
     @patch('usage_monitor_for_claude.popup.elapsed_pct', return_value=None)
     @patch('usage_monitor_for_claude.popup.time_until', return_value='')
-    @patch('usage_monitor_for_claude.popup.midnight_positions', return_value=[])
-    def test_status_live_mode_keys(self, _mock_mid, _mock_tu, _mock_ep):
+    @patch('usage_monitor_for_claude.popup.divider_positions', return_value=[])
+    def test_status_live_mode_keys(self, _mock_div, _mock_tu, _mock_ep):
         """Live mode status contains all required keys for the JS timer."""
         usage = {'five_hour': {'utilization': 50, 'resets_at': '2026-01-01T05:00:00Z'}}
         result = _snapshot_to_dict(
@@ -424,8 +424,8 @@ class TestSnapshotToDict(unittest.TestCase):
 
     @patch('usage_monitor_for_claude.popup.elapsed_pct', return_value=None)
     @patch('usage_monitor_for_claude.popup.time_until', return_value='')
-    @patch('usage_monitor_for_claude.popup.midnight_positions', return_value=[])
-    def test_status_error_truncated_in_live_mode(self, _mock_mid, _mock_tu, _mock_ep):
+    @patch('usage_monitor_for_claude.popup.divider_positions', return_value=[])
+    def test_status_error_truncated_in_live_mode(self, _mock_div, _mock_tu, _mock_ep):
         """Error messages are truncated to 120 characters in live mode."""
         usage = {'five_hour': {'utilization': 50, 'resets_at': '2026-01-01T05:00:00Z'}}
         long_error = 'x' * 200

--- a/usage_monitor_for_claude/formatting.py
+++ b/usage_monitor_for_claude/formatting.py
@@ -15,8 +15,8 @@ from .i18n import T
 from .settings import CURRENCY_SYMBOL, TOOLTIP_FIELDS, _SYSTEM_CURRENCY_SYMBOL
 
 __all__ = [
-    'elapsed_pct', 'expand_popup_fields', 'field_period', 'format_credits', 'format_tooltip',
-    'midnight_positions', 'parse_field_name', 'popup_label', 'time_until', 'tooltip_label',
+    'divider_positions', 'elapsed_pct', 'expand_popup_fields', 'field_period', 'format_credits',
+    'format_tooltip', 'parse_field_name', 'popup_label', 'time_until', 'tooltip_label',
 ]
 
 PERIOD_5H = 5 * 3600
@@ -218,8 +218,14 @@ def elapsed_pct(resets_at: str, period_seconds: int) -> float | None:
         return None
 
 
-def midnight_positions(resets_at: str, period_seconds: int) -> list[float]:
-    """Return relative positions (0.0-1.0) of local midnight boundaries within a usage period.
+def divider_positions(resets_at: str, period_seconds: int) -> list[float]:
+    """Return relative positions (0.0-1.0) of divider marks within a usage period.
+
+    Five-hour periods are split into five equal hour sections, independent
+    of clock alignment.  Periods of a day or longer are subdivided at local
+    midnight boundaries (e.g. seven day marks on a weekly bar).  Other
+    sub-day periods have no dividers - their subdivision is a deliberate
+    design decision for if and when such quota types exist.
 
     Parameters
     ----------
@@ -231,15 +237,21 @@ def midnight_positions(resets_at: str, period_seconds: int) -> list[float]:
     Returns
     -------
     list[float]
-        Positions where local midnights fall within the period, each in the
-        range (0.0, 1.0) exclusive.  Positions that would round to 0px at
-        typical bar widths are omitted.
+        Divider positions within the period, each in the range (0.0, 1.0)
+        exclusive.  Positions that would round to 0px at typical bar
+        widths are omitted.
     """
     if not resets_at or period_seconds <= 0:
         return []
 
     try:
         reset_utc = datetime.fromisoformat(resets_at)
+
+        if period_seconds < 24 * 3600:
+            if period_seconds != PERIOD_5H:
+                return []
+            return [i / 5 for i in range(1, 5)]
+
         start_utc = reset_utc - timedelta(seconds=period_seconds)
 
         start_local = start_utc.astimezone()

--- a/usage_monitor_for_claude/popup.py
+++ b/usage_monitor_for_claude/popup.py
@@ -21,7 +21,7 @@ import webview  # type: ignore[import-untyped]  # no type stubs available
 
 from . import __version__
 from .claude_cli import CHANGELOG_URL, find_installations
-from .formatting import elapsed_pct, expand_popup_fields, field_period, format_credits, midnight_positions, popup_label, time_until
+from .formatting import divider_positions, elapsed_pct, expand_popup_fields, field_period, format_credits, popup_label, time_until
 from .i18n import T
 from .settings import BAR_BG, BAR_DIVIDER, BAR_FG, BAR_FG_WARN, BAR_MARKER, BG, FG, FG_DIM, FG_HEADING, FG_LINK, POPUP_FIELDS
 
@@ -103,7 +103,7 @@ def _snapshot_to_dict(
                 'fill_pct': max(0.0, min(1.0, pct / 100)),
                 'warn': warn,
                 'reset_text': time_until(resets_at) if resets_at else '',
-                'midnights': midnight_positions(resets_at, period) if period else [],
+                'dividers': divider_positions(resets_at, period) if period else [],
                 'marker_rel': marker_rel,
             })
 

--- a/usage_monitor_for_claude/popup/dev.html
+++ b/usage_monitor_for_claude/popup/dev.html
@@ -81,13 +81,13 @@ const PRESETS = {
         profile: { email: 'user@example.com', plan: 'Max (Team)' },
         usage: [
             { label: 'Session (5hr)', pct_text: '42%', fill_pct: 0.42, warn: false,
-              reset_text: 'Resets in 2h 30m (14:30)', midnights: [], marker_rel: 0.35 },
+              reset_text: 'Resets in 2h 30m (14:30)', dividers: [0.2, 0.4, 0.6, 0.8], marker_rel: 0.35 },
             { label: 'Weekly (7 day)', pct_text: '65%', fill_pct: 0.65, warn: true,
-              reset_text: 'Resets on Sat, 12:00', midnights: [0.143, 0.286, 0.429, 0.571, 0.714, 0.857], marker_rel: 0.55 },
+              reset_text: 'Resets on Sat, 12:00', dividers: [0.143, 0.286, 0.429, 0.571, 0.714, 0.857], marker_rel: 0.55 },
             { label: 'Weekly (Sonnet)', pct_text: '30%', fill_pct: 0.30, warn: false,
-              reset_text: 'Resets on Sat, 12:00', midnights: [0.143, 0.286, 0.429, 0.571, 0.714, 0.857], marker_rel: 0.55 },
+              reset_text: 'Resets on Sat, 12:00', dividers: [0.143, 0.286, 0.429, 0.571, 0.714, 0.857], marker_rel: 0.55 },
             { label: 'Weekly (Opus)', pct_text: '12%', fill_pct: 0.12, warn: false,
-              reset_text: 'Resets on Sat, 12:00', midnights: [0.143, 0.286, 0.429, 0.571, 0.714, 0.857], marker_rel: 0.55 },
+              reset_text: 'Resets on Sat, 12:00', dividers: [0.143, 0.286, 0.429, 0.571, 0.714, 0.857], marker_rel: 0.55 },
         ],
         extra: { pct_text: '23%', fill_pct: 0.23, spent_text: '$4.60 / $20.00 spent' },
         installations: [
@@ -101,7 +101,7 @@ const PRESETS = {
         profile: null,
         usage: [
             { label: 'Session (5hr)', pct_text: '10%', fill_pct: 0.10, warn: false,
-              reset_text: 'Resets in 4h 50m (17:00)', midnights: [], marker_rel: 0.03 },
+              reset_text: 'Resets in 4h 50m (17:00)', dividers: [0.2, 0.4, 0.6, 0.8], marker_rel: 0.03 },
         ],
         extra: null,
         installations: [],
@@ -111,9 +111,9 @@ const PRESETS = {
         profile: { email: 'user@example.com', plan: 'Max' },
         usage: [
             { label: 'Session (5hr)', pct_text: '95%', fill_pct: 0.95, warn: true,
-              reset_text: 'Resets in 12m (12:12)', midnights: [], marker_rel: 0.96 },
+              reset_text: 'Resets in 12m (12:12)', dividers: [0.2, 0.4, 0.6, 0.8], marker_rel: 0.96 },
             { label: 'Weekly (7 day)', pct_text: '88%', fill_pct: 0.88, warn: true,
-              reset_text: 'Resets tomorrow, 08:00', midnights: [0.143, 0.286, 0.429, 0.571, 0.714, 0.857], marker_rel: 0.80 },
+              reset_text: 'Resets tomorrow, 08:00', dividers: [0.143, 0.286, 0.429, 0.571, 0.714, 0.857], marker_rel: 0.80 },
         ],
         extra: null,
         installations: [{ name: 'CLI', version: '2.1.69' }],
@@ -123,7 +123,7 @@ const PRESETS = {
         profile: { email: 'user@example.com', plan: 'Max (Team)' },
         usage: [
             { label: 'Session (5hr)', pct_text: '42%', fill_pct: 0.42, warn: false,
-              reset_text: 'Resets in 2h 30m (14:30)', midnights: [], marker_rel: 0.35 },
+              reset_text: 'Resets in 2h 30m (14:30)', dividers: [0.2, 0.4, 0.6, 0.8], marker_rel: 0.35 },
         ],
         extra: null,
         installations: [{ name: 'CLI', version: '2.1.69' }],

--- a/usage_monitor_for_claude/popup/popup.js
+++ b/usage_monitor_for_claude/popup/popup.js
@@ -245,7 +245,7 @@ function createBarElement(entry) {
     fill.style.width = '0%';
     container.appendChild(fill);
 
-    for (const pos of entry.midnights) {
+    for (const pos of entry.dividers) {
         const d = document.createElement('div');
         d.className = 'bar-divider';
         d.style.left = `calc(${pos * 100}% - 1px)`;
@@ -292,7 +292,7 @@ function updateBarElement(div, entry) {
     }
 
     for (const d of container.querySelectorAll('.bar-divider')) d.remove();
-    for (const pos of entry.midnights) {
+    for (const pos of entry.dividers) {
         const d = document.createElement('div');
         d.className = 'bar-divider';
         d.style.left = `${pos * 100}%`;


### PR DESCRIPTION
## Summary

The weekly popup bars are visually grouped into day segments by midnight
dividers, but the session bar had no comparable subdivision. The 5-hour session
bar is now split into five equal hour sections - the same visual language as
the weekly bars.

- `midnight_positions()` is generalized to `divider_positions()` (and the JS
  data key `midnights` to `dividers`): five-hour periods return four positions
  at exact fifths; day-or-longer periods keep the existing midnight logic
  byte-for-byte unchanged.
- Gating is on the period value (`PERIOD_5H`), not the field name, so 5-hour
  variants are auto-detected per the project's field-detection rules; other
  sub-day durations deliberately return no dividers until such quota types
  exist.
- Equal sections (rather than wall-clock hour boundaries) keep the dividers
  stable regardless of when a session starts, mirroring how the weekly bar
  reads as seven equal day segments.

<img width="356" height="230" alt="image" src="https://github.com/user-attachments/assets/cb15a034-8302-4fd5-9e90-dc16f6421fe2" />

## Workflow checklist

- [x] Read `.claude/CLAUDE.md` and followed the project conventions
- [x] Ran the `/review` slash command on all staged changes
- [ ] Used `/commit-message` to generate the commit message(s)
- [x] Ran the full test suite: `python -m unittest discover -s tests`

## User-facing changes

- [x] `README.md` updated ("Reading the progress bars" section)
- [x] `docs/configuration.md` updated (`bar_divider` description)
- [ ] Locale files - n/a, dividers are purely graphical

## Notes for reviewers

- No CSS or rendering changes - popup.js draws whatever positions it receives.
- dev.html presets updated to the new key with realistic session dividers.
- Tests pin: even-split invariance across window alignments (hour-aligned,
  mid-hour, midnight-spanning), the 24h boundary rule, and that existing
  midnight behavior and near-zero filtering are preserved.

