### PR TITLE
feat: support multiple instances via --config-dir, one per Claude account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Multi-account support - launch additional instances with `--config-dir="<path>"` to monitor a second Claude account side by side; each instance reads its own credentials and settings, gets its own tray tooltip prefix and autostart entry, and keeps its `--config-dir` across restarts
+
+### Changed
+
+- When a custom config directory is in effect (`--config-dir` or `CLAUDE_CONFIG_DIR`), a `usage-monitor-settings.json` in that directory now takes priority over the one next to the EXE, so each instance can have its own settings
+
 [Show all code changes](https://github.com/jens-duttke/usage-monitor-for-claude/compare/v1.19.0...HEAD)
 
 ## [1.19.0] - 2026-07-14

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A native Windows tray app that shows your Claude usage at a glance - lightweight
 - **Time marker** on each bar showing elapsed time in the current period - in the detail popup and on the tray icon bars - so you can instantly see whether your usage is ahead of or behind the clock; bars that outpace the clock turn red, in the popup and tray alike
 - **Automatic token refresh** - when the OAuth session expires, runs `claude update` in the background to renew the token without user intervention. If a CLI update is installed, shows a notification (which you can turn off via the `notify_claude_update` setting)
 - **Adaptive polling** - speeds up during active usage, pauses when the computer is idle or locked, aligns to imminent quota resets, and backs off on rate-limit errors. Switching your Claude account refreshes the tray immediately, so it never lingers on the previous account's usage
+- **Multi-account** - monitor several Claude accounts side by side: launch one instance per account with `--config-dir="<path>"` pointing at each account's Claude config directory. Each tray icon shows its account's usage, with a `[dir-name]` tooltip prefix, per-instance settings, and its own autostart entry
 - **13 languages** (English, German, French, Spanish, Portuguese, Italian, Japanese, Korean, Hindi, Indonesian, Chinese Simplified, Chinese Traditional, Ukrainian) - auto-detected from your Windows display language, with optional manual override via the `language` setting
 - **[Customizable](docs/configuration.md)** - optionally override polling intervals, colors, alert thresholds, and more via a JSON settings file
 
@@ -50,7 +51,7 @@ This tool handles your Claude Code OAuth token, so you should be able to verify 
 ## Requirements
 
 - **Windows 10 or Windows 11** (64-bit)
-- **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)** installed and logged in (CLI, VS Code extension, or JetBrains plugin - any variant works). The app reads the OAuth token that Claude Code stores locally (`~/.claude/.credentials.json`). If you have `CLAUDE_CONFIG_DIR` set, the app uses that directory instead.
+- **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)** installed and logged in (CLI, VS Code extension, or JetBrains plugin - any variant works). The app reads the OAuth token that Claude Code stores locally (`~/.claude/.credentials.json`). If you have `CLAUDE_CONFIG_DIR` set, the app uses that directory instead, and the `--config-dir="<path>"` command-line parameter overrides both - useful to run one instance per Claude account (log each extra account in via Claude Code with `CLAUDE_CONFIG_DIR` pointing to its own directory first).
 
 > [!TIP]
 > If the token expires, the app automatically runs `claude update` to refresh it. If the token is missing entirely, the app shows a notification and a "!" icon - log in to Claude Code and the monitor picks it up automatically.
@@ -104,10 +105,11 @@ All settings work out of the box - no configuration file is needed. To customize
 }
 ```
 
-The app searches for this file in two locations (first match wins):
+The app searches for this file in these locations (first match wins):
 
-1. **Next to the EXE** (or project root when running from source)
-2. **`~/.claude/usage-monitor-settings.json`** (or `$CLAUDE_CONFIG_DIR/usage-monitor-settings.json` if set)
+1. **`$CLAUDE_CONFIG_DIR/usage-monitor-settings.json`** (when a custom config directory is set via `--config-dir` or `CLAUDE_CONFIG_DIR`) - so each instance can have its own settings
+2. **Next to the EXE** (or project root when running from source)
+3. **`~/.claude/usage-monitor-settings.json`**
 
 The app never creates or modifies this file. See [Configuration](docs/configuration.md) for all available settings (alert thresholds, polling intervals, colors, language, and more).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,8 +12,8 @@ All settings work out of the box - no configuration file is needed. To customize
 
 The app searches for this file in these locations (first match wins):
 
-1. **Next to the EXE** (or project root when running from source)
-2. **`$CLAUDE_CONFIG_DIR/usage-monitor-settings.json`** (only if `CLAUDE_CONFIG_DIR` is set and differs from `~/.claude/`)
+1. **`$CLAUDE_CONFIG_DIR/usage-monitor-settings.json`** (only if a custom config directory is set via `--config-dir` or `CLAUDE_CONFIG_DIR` and differs from `~/.claude/`) - this lets every instance have its own settings when running one instance per Claude account
+2. **Next to the EXE** (or project root when running from source)
 3. **`~/.claude/usage-monitor-settings.json`**
 
 The app never creates or modifies this file. To start, create an empty file and add keys as needed. Settings are read at startup - after editing the file, use the **Restart** option in the tray context menu to apply changes.

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -13,7 +13,19 @@ from unittest.mock import MagicMock, patch
 import usage_monitor_for_claude.autostart as autostart_mod
 
 
-class TestIsAutostartEnabled(unittest.TestCase):
+class _DefaultConfigDirTestCase(unittest.TestCase):
+    """Base class pinning the default config dir (no per-instance suffix)."""
+
+    def setUp(self):
+        patcher_suffix = patch.object(autostart_mod, 'config_dir_suffix', return_value='')
+        patcher_default = patch.object(autostart_mod, 'is_default_config_dir', return_value=True)
+        patcher_suffix.start()
+        patcher_default.start()
+        self.addCleanup(patcher_suffix.stop)
+        self.addCleanup(patcher_default.stop)
+
+
+class TestIsAutostartEnabled(_DefaultConfigDirTestCase):
     """Tests for is_autostart_enabled()."""
 
     @patch.object(autostart_mod, 'winreg')
@@ -24,7 +36,7 @@ class TestIsAutostartEnabled(unittest.TestCase):
         mock_winreg.OpenKey.return_value.__exit__ = MagicMock(return_value=False)
 
         self.assertTrue(autostart_mod.is_autostart_enabled())
-        mock_winreg.QueryValueEx.assert_called_once_with(mock_key, autostart_mod.AUTOSTART_REG_NAME)
+        mock_winreg.QueryValueEx.assert_called_once_with(mock_key, autostart_mod.AUTOSTART_REG_BASE_NAME)
 
     @patch.object(autostart_mod, 'winreg')
     def test_returns_false_when_key_missing(self, mock_winreg):
@@ -56,7 +68,7 @@ class TestIsAutostartEnabled(unittest.TestCase):
         )
 
 
-class TestSetAutostart(unittest.TestCase):
+class TestSetAutostart(_DefaultConfigDirTestCase):
     """Tests for set_autostart()."""
 
     @patch.object(autostart_mod, 'winreg')
@@ -69,7 +81,7 @@ class TestSetAutostart(unittest.TestCase):
         autostart_mod.set_autostart(True)
 
         mock_winreg.SetValueEx.assert_called_once_with(
-            mock_key, autostart_mod.AUTOSTART_REG_NAME, 0,
+            mock_key, autostart_mod.AUTOSTART_REG_BASE_NAME, 0,
             mock_winreg.REG_SZ, f'"{sys.executable}"',
         )
 
@@ -82,7 +94,7 @@ class TestSetAutostart(unittest.TestCase):
 
         autostart_mod.set_autostart(False)
 
-        mock_winreg.DeleteValue.assert_called_once_with(mock_key, autostart_mod.AUTOSTART_REG_NAME)
+        mock_winreg.DeleteValue.assert_called_once_with(mock_key, autostart_mod.AUTOSTART_REG_BASE_NAME)
         mock_winreg.SetValueEx.assert_not_called()
 
     @patch.object(autostart_mod, 'winreg')
@@ -119,12 +131,12 @@ class TestSetAutostart(unittest.TestCase):
             autostart_mod.set_autostart(True)
 
         mock_winreg.SetValueEx.assert_called_once_with(
-            mock_key, autostart_mod.AUTOSTART_REG_NAME, 0,
+            mock_key, autostart_mod.AUTOSTART_REG_BASE_NAME, 0,
             mock_winreg.REG_SZ, r'"C:\Program Files\MyApp\app.exe"',
         )
 
 
-class TestSyncAutostartPath(unittest.TestCase):
+class TestSyncAutostartPath(_DefaultConfigDirTestCase):
     """Tests for sync_autostart_path()."""
 
     @patch.object(autostart_mod, 'winreg')
@@ -164,6 +176,83 @@ class TestSyncAutostartPath(unittest.TestCase):
         autostart_mod.sync_autostart_path()
 
         mock_set.assert_not_called()
+
+
+class TestCustomConfigDirAutostart(unittest.TestCase):
+    """Per-instance registry naming and command for a non-default config dir."""
+
+    def setUp(self):
+        patcher_suffix = patch.object(autostart_mod, 'config_dir_suffix', return_value='_abc123def456')
+        patcher_default = patch.object(autostart_mod, 'is_default_config_dir', return_value=False)
+        patcher_env = patch.dict('os.environ', {'CLAUDE_CONFIG_DIR': r'C:\Users\test\.claude-second'})
+        patcher_suffix.start()
+        patcher_default.start()
+        patcher_env.start()
+        self.addCleanup(patcher_suffix.stop)
+        self.addCleanup(patcher_default.stop)
+        self.addCleanup(patcher_env.stop)
+
+    @patch.object(autostart_mod, 'winreg')
+    def test_enable_uses_suffixed_value_name(self, mock_winreg):
+        """Non-default config dir writes a suffixed registry value name."""
+        mock_key = MagicMock()
+        mock_winreg.OpenKey.return_value.__enter__ = MagicMock(return_value=mock_key)
+        mock_winreg.OpenKey.return_value.__exit__ = MagicMock(return_value=False)
+
+        autostart_mod.set_autostart(True)
+
+        name = mock_winreg.SetValueEx.call_args[0][1]
+        self.assertEqual(name, 'UsageMonitorForClaude_abc123def456')
+
+    @patch.object(autostart_mod, 'winreg')
+    def test_enable_command_includes_config_dir(self, mock_winreg):
+        """Stored command carries --config-dir so autostart targets the right account."""
+        mock_key = MagicMock()
+        mock_winreg.OpenKey.return_value.__enter__ = MagicMock(return_value=mock_key)
+        mock_winreg.OpenKey.return_value.__exit__ = MagicMock(return_value=False)
+
+        autostart_mod.set_autostart(True)
+
+        command = mock_winreg.SetValueEx.call_args[0][4]
+        self.assertEqual(command, f'"{sys.executable}" --config-dir="C:\\Users\\test\\.claude-second"')
+
+    @patch.object(autostart_mod, 'winreg')
+    def test_disable_deletes_suffixed_value(self, mock_winreg):
+        """Disabling removes the per-instance registry value."""
+        mock_key = MagicMock()
+        mock_winreg.OpenKey.return_value.__enter__ = MagicMock(return_value=mock_key)
+        mock_winreg.OpenKey.return_value.__exit__ = MagicMock(return_value=False)
+
+        autostart_mod.set_autostart(False)
+
+        mock_winreg.DeleteValue.assert_called_once_with(mock_key, 'UsageMonitorForClaude_abc123def456')
+
+    @patch.object(autostart_mod, 'set_autostart')
+    @patch.object(autostart_mod, 'winreg')
+    def test_sync_skips_when_command_matches(self, mock_winreg, mock_set):
+        """sync_autostart_path() compares against the command including --config-dir."""
+        mock_key = MagicMock()
+        mock_winreg.OpenKey.return_value.__enter__ = MagicMock(return_value=mock_key)
+        mock_winreg.OpenKey.return_value.__exit__ = MagicMock(return_value=False)
+        stored = f'"{sys.executable}" --config-dir="C:\\Users\\test\\.claude-second"'
+        mock_winreg.QueryValueEx.return_value = (stored, 1)
+
+        autostart_mod.sync_autostart_path()
+
+        mock_set.assert_not_called()
+
+    @patch.object(autostart_mod, 'set_autostart')
+    @patch.object(autostart_mod, 'winreg')
+    def test_sync_updates_when_flag_missing(self, mock_winreg, mock_set):
+        """A stored command without --config-dir is rewritten."""
+        mock_key = MagicMock()
+        mock_winreg.OpenKey.return_value.__enter__ = MagicMock(return_value=mock_key)
+        mock_winreg.OpenKey.return_value.__exit__ = MagicMock(return_value=False)
+        mock_winreg.QueryValueEx.return_value = (f'"{sys.executable}"', 1)
+
+        autostart_mod.sync_autostart_path()
+
+        mock_set.assert_called_once_with(True)
 
 
 if __name__ == '__main__':

--- a/tests/test_instance_id.py
+++ b/tests/test_instance_id.py
@@ -1,0 +1,111 @@
+"""
+Instance Identity Tests
+========================
+
+Unit tests for --config-dir parsing and per-instance name suffixes.
+"""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from usage_monitor_for_claude.instance_id import config_dir_suffix, effective_config_dir, is_default_config_dir, parse_config_dir
+
+
+class TestParseConfigDir(unittest.TestCase):
+    """Tests for parse_config_dir()."""
+
+    def test_equals_form(self):
+        self.assertEqual(parse_config_dir(['app.exe', r'--config-dir=C:\dir']), r'C:\dir')
+
+    def test_space_form(self):
+        self.assertEqual(parse_config_dir(['app.exe', '--config-dir', r'C:\dir']), r'C:\dir')
+
+    def test_absent_flag_returns_none(self):
+        self.assertIsNone(parse_config_dir(['app.exe', '--verbose']))
+
+    def test_flag_without_value_returns_none(self):
+        self.assertIsNone(parse_config_dir(['app.exe', '--config-dir']))
+
+    def test_empty_value_returns_none(self):
+        self.assertIsNone(parse_config_dir(['app.exe', '--config-dir=']))
+
+    def test_strips_surrounding_quotes(self):
+        self.assertEqual(parse_config_dir(['app.exe', '--config-dir="C:\\dir"']), r'C:\dir')
+
+    def test_strips_trailing_quote_from_cmd_quoting(self):
+        """cmd.exe turns --config-dir="C:\\dir\\" into a value with a trailing quote."""
+        self.assertEqual(parse_config_dir(['app.exe', '--config-dir=C:\\dir\\"']), r'C:\dir')
+
+    def test_strips_trailing_backslash(self):
+        self.assertEqual(parse_config_dir(['app.exe', '--config-dir=C:\\dir\\']), r'C:\dir')
+
+    def test_expands_environment_variables(self):
+        """%VAR% syntax works even from shells that do not expand it (PowerShell)."""
+        with patch.dict('os.environ', {'USERPROFILE': r'C:\Users\test'}):
+            result = parse_config_dir(['app.exe', '--config-dir=%USERPROFILE%\\.claude-second'])
+        self.assertEqual(result, r'C:\Users\test\.claude-second')
+
+    def test_expands_tilde(self):
+        with patch.dict('os.environ', {'USERPROFILE': r'C:\Users\test'}):
+            result = parse_config_dir(['app.exe', '--config-dir=~/.claude-second'])
+        self.assertEqual(result, r'C:\Users\test\.claude-second')
+
+    def test_last_occurrence_wins(self):
+        argv = ['app.exe', '--config-dir=C:\\first', '--config-dir=C:\\second']
+        self.assertEqual(parse_config_dir(argv), r'C:\second')
+
+
+class TestConfigDirSuffix(unittest.TestCase):
+    """Tests for config_dir_suffix() and is_default_config_dir()."""
+
+    def test_default_when_env_unset(self):
+        with patch.dict('os.environ', {}, clear=False):
+            import os
+            os.environ.pop('CLAUDE_CONFIG_DIR', None)
+            self.assertTrue(is_default_config_dir())
+            self.assertEqual(config_dir_suffix(), '')
+
+    def test_default_when_env_points_to_home_claude(self):
+        with TemporaryDirectory() as home_tmp:
+            claude_dir = Path(home_tmp) / '.claude'
+            claude_dir.mkdir()
+            with patch.object(Path, 'home', return_value=Path(home_tmp)), \
+                 patch.dict('os.environ', {'CLAUDE_CONFIG_DIR': str(claude_dir)}):
+                self.assertTrue(is_default_config_dir())
+                self.assertEqual(config_dir_suffix(), '')
+
+    def test_custom_dir_produces_suffix(self):
+        with TemporaryDirectory() as config_tmp:
+            with patch.dict('os.environ', {'CLAUDE_CONFIG_DIR': config_tmp}):
+                self.assertFalse(is_default_config_dir())
+                suffix = config_dir_suffix()
+        self.assertTrue(suffix.startswith('_'))
+        self.assertEqual(len(suffix), 13)
+
+    def test_suffix_stable_across_casing_and_trailing_slash(self):
+        with TemporaryDirectory() as config_tmp:
+            with patch.dict('os.environ', {'CLAUDE_CONFIG_DIR': config_tmp}):
+                suffix_plain = config_dir_suffix()
+            with patch.dict('os.environ', {'CLAUDE_CONFIG_DIR': config_tmp.upper() + '\\'}):
+                suffix_variant = config_dir_suffix()
+        self.assertEqual(suffix_plain, suffix_variant)
+
+    def test_different_dirs_produce_different_suffixes(self):
+        with TemporaryDirectory() as dir_a, TemporaryDirectory() as dir_b:
+            with patch.dict('os.environ', {'CLAUDE_CONFIG_DIR': dir_a}):
+                suffix_a = config_dir_suffix()
+            with patch.dict('os.environ', {'CLAUDE_CONFIG_DIR': dir_b}):
+                suffix_b = config_dir_suffix()
+        self.assertNotEqual(suffix_a, suffix_b)
+
+    def test_effective_config_dir_resolves_env_value(self):
+        with TemporaryDirectory() as config_tmp:
+            with patch.dict('os.environ', {'CLAUDE_CONFIG_DIR': config_tmp}):
+                self.assertEqual(effective_config_dir(), Path(config_tmp).resolve())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -109,6 +109,18 @@ class TestLoadSettings(unittest.TestCase):
                 result = settings_mod._load_settings()
         self.assertEqual(result, settings)
 
+    def test_custom_config_dir_wins_over_app_dir(self):
+        """A custom config dir file takes priority over the exe-adjacent file."""
+        with TemporaryDirectory() as app_tmp, TemporaryDirectory() as config_tmp:
+            (Path(app_tmp) / settings_mod.SETTINGS_FILENAME).write_text(json.dumps({'bg': '#app'}), encoding='utf-8')
+            (Path(config_tmp) / settings_mod.SETTINGS_FILENAME).write_text(json.dumps({'bg': '#custom'}), encoding='utf-8')
+            fake_file = str(Path(app_tmp) / 'usage_monitor_for_claude' / 'settings.py')
+            with patch.object(settings_mod, '__file__', fake_file), \
+                 patch.dict('os.environ', {'CLAUDE_CONFIG_DIR': config_tmp}), \
+                 patch.object(settings_mod, 'ctypes', MagicMock()):
+                result = settings_mod._load_settings()
+        self.assertEqual(result['bg'], '#custom')
+
     def test_app_dir_takes_priority(self):
         """File next to app wins over ~/.claude/ file."""
         with TemporaryDirectory() as app_tmp, TemporaryDirectory() as home_tmp:

--- a/tests/test_single_instance.py
+++ b/tests/test_single_instance.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import unittest
+from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
 
 MODULE = 'usage_monitor_for_claude.single_instance'
@@ -176,6 +177,47 @@ class TestEnsureSingleInstance(unittest.TestCase):
 
         message = mock_user32.MessageBoxW.call_args[0][1]
         self.assertIn('?', message)
+
+
+# ---------------------------------------------------------------------------
+# Per-instance object names
+# ---------------------------------------------------------------------------
+
+class TestObjectNames(unittest.TestCase):
+    """Tests for _object_names() per-config-dir suffixing."""
+
+    def test_default_config_dir_uses_legacy_names(self):
+        """Default config dir keeps the unsuffixed names for cross-version detection."""
+        import usage_monitor_for_claude.single_instance as si
+
+        with patch(f'{MODULE}.config_dir_suffix', return_value=''):
+            mutex_name, mapping_name = si._object_names()
+
+        self.assertEqual(mutex_name, 'UsageMonitorForClaude_SingleInstance')
+        self.assertEqual(mapping_name, 'UsageMonitorForClaude_HolderPID')
+
+    def test_custom_config_dir_appends_suffix(self):
+        """A custom config dir yields suffixed, per-instance names."""
+        import usage_monitor_for_claude.single_instance as si
+
+        with patch(f'{MODULE}.config_dir_suffix', return_value='_abc123def456'):
+            mutex_name, mapping_name = si._object_names()
+
+        self.assertEqual(mutex_name, 'UsageMonitorForClaude_SingleInstance_abc123def456')
+        self.assertEqual(mapping_name, 'UsageMonitorForClaude_HolderPID_abc123def456')
+
+    def test_two_config_dirs_get_distinct_names(self):
+        """Two different config dirs never collide on kernel object names."""
+        import usage_monitor_for_claude.single_instance as si
+
+        with TemporaryDirectory() as dir_a, TemporaryDirectory() as dir_b:
+            with patch.dict('os.environ', {'CLAUDE_CONFIG_DIR': dir_a}):
+                names_a = si._object_names()
+            with patch.dict('os.environ', {'CLAUDE_CONFIG_DIR': dir_b}):
+                names_b = si._object_names()
+
+        self.assertNotEqual(names_a[0], names_b[0])
+        self.assertNotEqual(names_a[1], names_b[1])
 
 
 # ---------------------------------------------------------------------------

--- a/usage_monitor_for_claude/__main__.py
+++ b/usage_monitor_for_claude/__main__.py
@@ -7,8 +7,26 @@ import os
 import subprocess
 import sys
 import traceback
+from pathlib import Path
+
+from usage_monitor_for_claude.instance_id import parse_config_dir
 
 _verbose = '--verbose' in sys.argv
+
+# --config-dir selects which Claude account to monitor. It must be
+# resolved into CLAUDE_CONFIG_DIR before any other package import:
+# api, settings, verbose and i18n all read the variable at import or
+# first-use time. Keep every other package import below this block.
+_config_dir = parse_config_dir(sys.argv)
+if _config_dir is not None:
+    _config_path = Path(_config_dir)
+    if not _config_path.is_dir():
+        ctypes.windll.user32.MessageBoxW(
+            0, f'--config-dir directory does not exist:\n{_config_dir}',
+            'Usage Monitor for Claude - Error', 0x10,
+        )
+        sys.exit(1)
+    os.environ['CLAUDE_CONFIG_DIR'] = str(_config_path.resolve())
 
 # In frozen builds (console=False), stdout/stderr go nowhere.
 # --verbose attaches a console so diagnostics are visible.
@@ -94,19 +112,25 @@ try:
     if app and app.restart_requested:
         release_instance_lock()
 
+        passthrough_args = []
+        if _config_dir is not None:
+            passthrough_args.append(f'--config-dir={os.environ["CLAUDE_CONFIG_DIR"]}')
+        if _verbose:
+            passthrough_args.append('--verbose')
+
         if getattr(sys, 'frozen', False):
             # Clear PyInstaller's internal env vars so the new
             # instance extracts to a fresh temp directory instead
             # of reusing the current (soon-to-be-deleted) one.
             env = {k: v for k, v in os.environ.items() if not k.startswith(('_PYI_', '_MEI'))}
             subprocess.Popen(
-                [sys.executable],
+                [sys.executable, *passthrough_args],
                 env=env,
                 creationflags=subprocess.CREATE_NO_WINDOW,
             )
         else:
             subprocess.Popen(
-                [sys.executable, '-m', 'usage_monitor_for_claude'],
+                [sys.executable, '-m', 'usage_monitor_for_claude', *passthrough_args],
                 creationflags=subprocess.CREATE_NO_WINDOW,
             )
 except Exception:

--- a/usage_monitor_for_claude/app.py
+++ b/usage_monitor_for_claude/app.py
@@ -24,6 +24,7 @@ from .cache import UsageCache
 from .claude_cli import PROJECT_URL
 from .command import run_event_command
 from .idle import get_idle_seconds, is_workstation_locked
+from .instance_id import effective_config_dir, is_default_config_dir
 from .settings import (
     ALERT_TIME_AWARE, ALERT_TIME_AWARE_BELOW, ICON_FIELDS, IDLE_PAUSE, NOTIFY_CLAUDE_UPDATE,
     ON_DOUBLE_CLICK_COMMAND, ON_RESET_COMMAND, ON_STARTUP_COMMAND, ON_THRESHOLD_COMMAND,
@@ -133,10 +134,14 @@ class UsageMonitorForClaude:
 
         self.restart_requested = False
 
+        # Non-default config dirs get a tooltip prefix so multiple
+        # instances (one per Claude account) can be told apart.
+        self._tooltip_prefix = '' if is_default_config_dir() else f'[{effective_config_dir().name}] '
+
         self.icon = pystray.Icon(
             'usage_monitor',
             icon=create_icon_image(0, 0, self._light_taskbar),
-            title=T['loading'],
+            title=self._tooltip_prefix + T['loading'],
             menu=pystray.Menu(
                 pystray.MenuItem(T['menu_show'], self.on_show_popup, default=True),
                 pystray.Menu.SEPARATOR,
@@ -397,7 +402,7 @@ class UsageMonitorForClaude:
                 time_pct_top=time_pct_top, time_pct_bottom=time_pct_bottom,
                 extra_usage_available=extra_usage_available,
             )
-        self.icon.title = format_tooltip(data)
+        self.icon.title = self._tooltip_prefix + format_tooltip(data)
 
     def _on_theme_changed(self) -> None:
         """Re-render the tray icon when the Windows theme changes."""

--- a/usage_monitor_for_claude/autostart.py
+++ b/usage_monitor_for_claude/autostart.py
@@ -3,16 +3,34 @@ Autostart
 ==========
 
 Manages Windows autostart via the ``HKCU\\...\\Run`` registry key.
+Each monitor instance (one per Claude config directory) uses its own
+registry value name and stores its ``--config-dir`` in the command.
 """
 from __future__ import annotations
 
+import os
 import sys
 import winreg
 
-__all__ = ['AUTOSTART_REG_KEY', 'AUTOSTART_REG_NAME', 'is_autostart_enabled', 'set_autostart', 'sync_autostart_path']
+from .instance_id import config_dir_suffix, is_default_config_dir
+
+__all__ = ['AUTOSTART_REG_KEY', 'AUTOSTART_REG_BASE_NAME', 'is_autostart_enabled', 'set_autostart', 'sync_autostart_path']
 
 AUTOSTART_REG_KEY = r'Software\Microsoft\Windows\CurrentVersion\Run'
-AUTOSTART_REG_NAME = 'UsageMonitorForClaude'
+AUTOSTART_REG_BASE_NAME = 'UsageMonitorForClaude'
+
+
+def _autostart_reg_name() -> str:
+    """Return the per-instance registry value name."""
+    return AUTOSTART_REG_BASE_NAME + config_dir_suffix()
+
+
+def _autostart_command() -> str:
+    """Return the command line to store in the registry for this instance."""
+    command = f'"{sys.executable}"'
+    if not is_default_config_dir():
+        command += f' --config-dir="{os.environ["CLAUDE_CONFIG_DIR"]}"'
+    return command
 
 
 def is_autostart_enabled() -> bool:
@@ -25,7 +43,7 @@ def is_autostart_enabled() -> bool:
     """
     try:
         with winreg.OpenKey(winreg.HKEY_CURRENT_USER, AUTOSTART_REG_KEY) as key:
-            winreg.QueryValueEx(key, AUTOSTART_REG_NAME)
+            winreg.QueryValueEx(key, _autostart_reg_name())
             return True
     except FileNotFoundError:
         return False
@@ -41,26 +59,25 @@ def set_autostart(enable: bool) -> None:
     """
     with winreg.OpenKey(winreg.HKEY_CURRENT_USER, AUTOSTART_REG_KEY, 0, winreg.KEY_SET_VALUE) as key:
         if enable:
-            winreg.SetValueEx(key, AUTOSTART_REG_NAME, 0, winreg.REG_SZ, f'"{sys.executable}"')
+            winreg.SetValueEx(key, _autostart_reg_name(), 0, winreg.REG_SZ, _autostart_command())
         else:
             try:
-                winreg.DeleteValue(key, AUTOSTART_REG_NAME)
+                winreg.DeleteValue(key, _autostart_reg_name())
             except FileNotFoundError:
                 pass
 
 
 def sync_autostart_path() -> None:
-    """Update the autostart registry path if the EXE has been moved.
+    """Update the autostart registry command if the EXE has been moved.
 
-    Compares the stored path with the current ``sys.executable`` and
+    Compares the stored command with the current expected one and
     silently updates the registry value when they differ.
     """
     try:
         with winreg.OpenKey(winreg.HKEY_CURRENT_USER, AUTOSTART_REG_KEY) as key:
-            stored, _ = winreg.QueryValueEx(key, AUTOSTART_REG_NAME)
+            stored, _ = winreg.QueryValueEx(key, _autostart_reg_name())
     except FileNotFoundError:
         return
 
-    expected = f'"{sys.executable}"'
-    if stored != expected:
+    if stored != _autostart_command():
         set_autostart(True)

--- a/usage_monitor_for_claude/autostart.py
+++ b/usage_monitor_for_claude/autostart.py
@@ -8,11 +8,10 @@ registry value name and stores its ``--config-dir`` in the command.
 """
 from __future__ import annotations
 
-import os
 import sys
 import winreg
 
-from .instance_id import config_dir_suffix, is_default_config_dir
+from .instance_id import config_dir_suffix, effective_config_dir, is_default_config_dir
 
 __all__ = ['AUTOSTART_REG_KEY', 'AUTOSTART_REG_BASE_NAME', 'is_autostart_enabled', 'set_autostart', 'sync_autostart_path']
 
@@ -29,7 +28,7 @@ def _autostart_command() -> str:
     """Return the command line to store in the registry for this instance."""
     command = f'"{sys.executable}"'
     if not is_default_config_dir():
-        command += f' --config-dir="{os.environ["CLAUDE_CONFIG_DIR"]}"'
+        command += f' --config-dir="{effective_config_dir()}"'
     return command
 
 

--- a/usage_monitor_for_claude/instance_id.py
+++ b/usage_monitor_for_claude/instance_id.py
@@ -1,0 +1,86 @@
+"""
+Instance Identity
+==================
+
+Derives a per-instance identifier from the effective Claude config
+directory so multiple monitor instances (one per Claude account) can
+coexist, each guarding its own single-instance mutex and autostart
+registry entry.
+
+This module must stay free of imports from ``api`` or ``settings`` -
+it is used before ``CLAUDE_CONFIG_DIR`` is finalized in ``__main__``.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+__all__ = ['config_dir_suffix', 'effective_config_dir', 'is_default_config_dir', 'parse_config_dir']
+
+
+def parse_config_dir(argv: list[str]) -> str | None:
+    """Extract the ``--config-dir`` value from command-line arguments.
+
+    Supports both ``--config-dir=PATH`` and ``--config-dir PATH`` forms.
+    Surrounding quotes and a stray trailing quote (left by cmd.exe when
+    the path ends with a backslash, e.g. ``--config-dir="C:\\dir\\"``)
+    are stripped.  Environment variables (``%USERPROFILE%``) and a
+    leading ``~`` are expanded, so the flag works the same from cmd.exe,
+    PowerShell, and shortcut targets.
+
+    Parameters
+    ----------
+    argv : list[str]
+        Argument list, typically ``sys.argv``.
+
+    Returns
+    -------
+    str | None
+        The cleaned path value, or ``None`` if the flag is absent or
+        has no value.
+    """
+    value = None
+    for index, arg in enumerate(argv):
+        if arg.startswith('--config-dir='):
+            value = arg.split('=', 1)[1]
+        elif arg == '--config-dir' and index + 1 < len(argv):
+            value = argv[index + 1]
+
+    if value is None:
+        return None
+
+    value = value.strip().strip('"').rstrip('\\/')
+    if not value:
+        return None
+
+    return str(Path(os.path.expandvars(value)).expanduser())
+
+
+def effective_config_dir() -> Path:
+    """Return the resolved Claude config directory currently in effect."""
+    custom = os.environ.get('CLAUDE_CONFIG_DIR')
+    base = Path(custom) if custom else Path.home() / '.claude'
+    return base.resolve()
+
+
+def is_default_config_dir() -> bool:
+    """Return True when the effective config dir is the default ``~/.claude``."""
+    default = (Path.home() / '.claude').resolve()
+    return os.path.normcase(str(effective_config_dir())) == os.path.normcase(str(default))
+
+
+def config_dir_suffix() -> str:
+    """Return a per-instance suffix for kernel object and registry names.
+
+    Empty for the default ``~/.claude`` directory (preserving the legacy
+    names so older versions are still detected), otherwise an underscore
+    plus a short hash of the resolved, case-normalized directory path.
+    Hashing keeps the names free of characters that are invalid in Win32
+    kernel object names (e.g. backslashes).
+    """
+    if is_default_config_dir():
+        return ''
+
+    normalized = os.path.normcase(str(effective_config_dir()))
+    return '_' + hashlib.sha1(normalized.encode('utf-8')).hexdigest()[:12]

--- a/usage_monitor_for_claude/settings.py
+++ b/usage_monitor_for_claude/settings.py
@@ -8,8 +8,8 @@ registry keys, file paths) remain in their respective modules.
 Loads an optional ``usage-monitor-settings.json`` to let users override
 any constant.  Search order:
 
-1. Next to the executable (frozen) or project root (source)
-2. ``$CLAUDE_CONFIG_DIR/usage-monitor-settings.json`` (if set and different from ``~/.claude/``)
+1. ``$CLAUDE_CONFIG_DIR/usage-monitor-settings.json`` (if set and different from ``~/.claude/``)
+2. Next to the executable (frozen) or project root (source)
 3. ``~/.claude/usage-monitor-settings.json``
 
 The app never creates this file - users place it manually.
@@ -20,9 +20,10 @@ import ctypes
 import ctypes.wintypes
 import json
 import locale as _locale
-import os
 import sys
 from pathlib import Path
+
+from .instance_id import effective_config_dir, is_default_config_dir
 
 __all__ = [
     'ALERT_TIME_AWARE', 'ALERT_TIME_AWARE_BELOW',
@@ -68,11 +69,13 @@ def _load_settings() -> dict:
         app_dir = Path(__file__).resolve().parent.parent
 
     home_claude = Path.home() / '.claude'
-    custom_config = Path(os.environ['CLAUDE_CONFIG_DIR']) if os.environ.get('CLAUDE_CONFIG_DIR') else None
 
-    search_paths = [app_dir / SETTINGS_FILENAME]
-    if custom_config and custom_config != home_claude:
-        search_paths.append(custom_config / SETTINGS_FILENAME)
+    # A custom config dir takes precedence over the exe-adjacent file so
+    # each instance (one per Claude account) can have its own settings.
+    search_paths = []
+    if not is_default_config_dir():
+        search_paths.append(effective_config_dir() / SETTINGS_FILENAME)
+    search_paths.append(app_dir / SETTINGS_FILENAME)
     search_paths.append(home_claude / SETTINGS_FILENAME)
 
     for path in search_paths:

--- a/usage_monitor_for_claude/single_instance.py
+++ b/usage_monitor_for_claude/single_instance.py
@@ -16,11 +16,12 @@ import struct
 
 from . import __version__
 from .i18n import T
+from .instance_id import config_dir_suffix
 
 __all__ = ['ensure_single_instance', 'release_instance_lock']
 
-_MUTEX_NAME = 'UsageMonitorForClaude_SingleInstance'
-_PID_MAPPING_NAME = 'UsageMonitorForClaude_HolderPID'
+_MUTEX_BASE_NAME = 'UsageMonitorForClaude_SingleInstance'
+_PID_MAPPING_BASE_NAME = 'UsageMonitorForClaude_HolderPID'
 _ERROR_ALREADY_EXISTS = 0xB7
 _INVALID_HANDLE = ctypes.c_void_p(-1).value
 _PAGE_READWRITE = 0x04
@@ -74,6 +75,17 @@ _mutex_handle: int | None = None
 _pid_mapping_handle: int | None = None
 
 
+def _object_names() -> tuple[str, str]:
+    """Return the per-instance ``(mutex_name, pid_mapping_name)`` pair.
+
+    The names carry a config-dir suffix so one monitor instance per
+    Claude account can run concurrently, each a singleton for its own
+    config directory.
+    """
+    suffix = config_dir_suffix()
+    return _MUTEX_BASE_NAME + suffix, _PID_MAPPING_BASE_NAME + suffix
+
+
 def _store_holder_info() -> None:
     """Store our PID and version in named shared memory.
 
@@ -82,7 +94,7 @@ def _store_holder_info() -> None:
     """
     global _pid_mapping_handle
     _pid_mapping_handle = _kernel32.CreateFileMappingW(
-        _INVALID_HANDLE, None, _PAGE_READWRITE, 0, _SHARED_MEM_SIZE, _PID_MAPPING_NAME,
+        _INVALID_HANDLE, None, _PAGE_READWRITE, 0, _SHARED_MEM_SIZE, _object_names()[1],
     )
     if not _pid_mapping_handle:
         return
@@ -106,7 +118,7 @@ def _read_holder_info() -> tuple[int | None, str | None]:
         ``(pid, version)`` of the holder, or ``(None, None)`` if the
         shared memory does not exist.
     """
-    mapping = _kernel32.OpenFileMappingW(_FILE_MAP_READ, False, _PID_MAPPING_NAME)
+    mapping = _kernel32.OpenFileMappingW(_FILE_MAP_READ, False, _object_names()[1])
     if not mapping:
         return None, None
 
@@ -162,7 +174,8 @@ def ensure_single_instance() -> bool:
         True if this instance may proceed, False if it should exit.
     """
     global _mutex_handle
-    _mutex_handle = _kernel32.CreateMutexW(None, False, _MUTEX_NAME)
+    mutex_name = _object_names()[0]
+    _mutex_handle = _kernel32.CreateMutexW(None, False, mutex_name)
     if ctypes.get_last_error() != _ERROR_ALREADY_EXISTS:
         _store_holder_info()
         return True
@@ -196,7 +209,7 @@ def ensure_single_instance() -> bool:
         _terminate_pid(holder_pid)
     _kernel32.CloseHandle(_mutex_handle)
 
-    _mutex_handle = _kernel32.CreateMutexW(None, False, _MUTEX_NAME)
+    _mutex_handle = _kernel32.CreateMutexW(None, False, mutex_name)
     _store_holder_info()
     return True
 


### PR DESCRIPTION
<!--
Thanks for contributing! This project is developed with Claude Code.
See `.claude/CLAUDE.md` for the full conventions.
-->

## Summary

Adds a `--config-dir="<path>"` command-line parameter so multiple monitor instances can run concurrently, one per Claude account (e.g. a second Claude Desktop profile logged into a different account via Claude Code with its own `CLAUDE_CONFIG_DIR`).

- `--config-dir` resolves into `CLAUDE_CONFIG_DIR` before any other module import, so credentials, settings resolution, and the `claude update` refresh subprocess all target the given account without further plumbing
- The single-instance mutex/shared-memory names and the autostart registry entry are suffixed per config directory, so each account's instance is a singleton on its own while multiple accounts' instances coexist; the default `~/.claude` instance keeps its legacy (unsuffixed) names for backward compatibility
- When a custom config directory is active, its own `usage-monitor-settings.json` now takes priority over the one next to the EXE, so each instance can have independent settings (e.g. distinguishing tray icons)
- The tray tooltip gets a `[config-dir-name]` prefix for non-default instances
- `--config-dir` (and `--verbose`) are preserved across the tray "Restart" action

## Workflow checklist

- [x] Read `.claude/CLAUDE.md` and followed the project conventions
- [x] Ran the `/review` slash command on all staged changes (code, tests, documentation)
- [x] Used `/commit-message` to generate the commit message(s)
- [x] Ran the full test suite: `python -m unittest discover -s tests`

## User-facing changes

- [x] `README.md` feature list updated
- [x] `docs/configuration.md` updated (settings search order now includes the custom config dir first)
- [ ] Locale files in `locale/` updated - no new user-visible strings were added (the tooltip prefix uses the config dir name, not translated text; the new error dialogs follow the existing untranslated pattern used by settings.py's JSON error dialog)

## Notes for reviewers

- Rebased onto v1.19.0 to avoid conflicts with the `on_double_click_command` and token-refresh-recovery changes
- New module `usage_monitor_for_claude/instance_id.py` centralizes config-dir resolution/parsing (stdlib-only, no imports from `api`/`settings`) so it can be used both before `CLAUDE_CONFIG_DIR` is finalized in `__main__.py` and by `single_instance.py`/`autostart.py`/`settings.py`/`app.py`
- 27 new/updated tests covering flag parsing (both forms, env-var/tilde expansion, quoting from cmd.exe), per-instance mutex/registry naming, and settings precedence