### PR TITLE
fix: decode 'claude update' output as UTF-8 to prevent crash on non-UTF-8 locales (#80)

### DIFF
--- a/tests/test_claude_cli.py
+++ b/tests/test_claude_cli.py
@@ -626,5 +626,60 @@ class TestRefreshTokenIgnoresCliCommand(unittest.TestCase):
         self.assertEqual(claude_cli._command_version_cache[('wsl', 'claude')], '2.1.204')
 
 
+# ---------------------------------------------------------------------------
+# refresh_token() on non-UTF-8 locales (regression: #80)
+# ---------------------------------------------------------------------------
+
+class TestRefreshTokenNonUtf8Locale(unittest.TestCase):
+    """Regression tests for the cp950/non-UTF-8 locale crash (issue #80).
+
+    ``claude update`` emits UTF-8.  When ``subprocess.run`` decodes its
+    pipes with the system locale codec (e.g. cp950), a non-ASCII glyph
+    kills the pipe-reader thread; CPython then hands back ``None`` for that
+    stream, and ``proc.stdout + proc.stderr`` raised ``TypeError``.
+    """
+
+    @patch('usage_monitor_for_claude.claude_cli.subprocess.run')
+    @patch('usage_monitor_for_claude.claude_cli.CLAUDE_CLI_PATH')
+    def test_decodes_output_as_utf8_regardless_of_locale(self, mock_path, mock_run):
+        """The CLI output is decoded as UTF-8, not the ambient locale codec."""
+        mock_path.is_file.return_value = True
+        mock_run.return_value = MagicMock(stdout='', stderr='', returncode=0)
+        refresh_token()
+        _args, kwargs = mock_run.call_args
+        self.assertEqual(kwargs.get('encoding'), 'utf-8')
+        self.assertEqual(kwargs.get('errors'), 'replace')
+
+    @patch('usage_monitor_for_claude.claude_cli.subprocess.run')
+    @patch('usage_monitor_for_claude.claude_cli.CLAUDE_CLI_PATH')
+    def test_survives_none_stderr_from_dead_pipe_thread(self, mock_path, mock_run):
+        """A ``None`` stderr (dead decode thread) must not raise TypeError.
+
+        This is the exact reported traceback: the update succeeded, stdout
+        carried the success line, but the stderr pipe-reader thread had died
+        and CPython returned ``None`` for it.
+        """
+        mock_path.is_file.return_value = True
+        mock_run.return_value = MagicMock(
+            stdout='Successfully updated from 2.1.38 to version 2.1.69',
+            stderr=None, returncode=0,
+        )
+        result = refresh_token()  # must not raise "can only concatenate str ... NoneType"
+        self.assertTrue(result.success)
+        self.assertTrue(result.updated)
+        self.assertEqual(result.old_version, '2.1.38')
+        self.assertEqual(result.new_version, '2.1.69')
+
+    @patch('usage_monitor_for_claude.claude_cli.subprocess.run')
+    @patch('usage_monitor_for_claude.claude_cli.CLAUDE_CLI_PATH')
+    def test_survives_both_streams_none(self, mock_path, mock_run):
+        """Both streams ``None`` (returncode 0) still resolves without crashing."""
+        mock_path.is_file.return_value = True
+        mock_run.return_value = MagicMock(stdout=None, stderr=None, returncode=0)
+        result = refresh_token()
+        self.assertTrue(result.success)
+        self.assertFalse(result.updated)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_claude_cli.py
+++ b/tests/test_claude_cli.py
@@ -168,7 +168,8 @@ class TestCliVersion(unittest.TestCase):
         cli_version(path)
         mock_run.assert_called_once_with(
             [str(path), '--version'],
-            capture_output=True, text=True, timeout=10, creationflags=subprocess.CREATE_NO_WINDOW,
+            capture_output=True, text=True, encoding='utf-8', errors='replace',
+            timeout=10, creationflags=subprocess.CREATE_NO_WINDOW,
         )
 
     @patch('usage_monitor_for_claude.claude_cli.subprocess.run')
@@ -465,7 +466,8 @@ class TestCommandVersion(unittest.TestCase):
         claude_cli._command_version(['wsl', '/home/user/.local/bin/claude'])
         mock_run.assert_called_once_with(
             ['wsl', '/home/user/.local/bin/claude', '--version'],
-            capture_output=True, text=True, timeout=10, creationflags=subprocess.CREATE_NO_WINDOW,
+            capture_output=True, text=True, encoding='utf-8', errors='replace',
+            timeout=10, creationflags=subprocess.CREATE_NO_WINDOW,
         )
 
     @patch('usage_monitor_for_claude.claude_cli.subprocess.run')
@@ -679,6 +681,79 @@ class TestRefreshTokenNonUtf8Locale(unittest.TestCase):
         result = refresh_token()
         self.assertTrue(result.success)
         self.assertFalse(result.updated)
+
+
+# ---------------------------------------------------------------------------
+# cli_version() / _command_version() on non-UTF-8 locales (regression: #80)
+# ---------------------------------------------------------------------------
+
+class TestVersionProbesNonUtf8Locale(unittest.TestCase):
+    """Same-root-cause regression as #80 for the two ``--version`` probes.
+
+    ``claude --version`` emits UTF-8.  When ``subprocess.run`` decodes its
+    pipes with the ambient locale codec (e.g. cp950), a non-ASCII glyph kills
+    the pipe-reader thread and CPython hands back ``None`` for that stream.
+
+    ``cli_version`` swallows the resulting ``AttributeError`` in its broad
+    ``except`` (so it silently loses the version), but ``_command_version``
+    parses ``proc.stdout`` *outside* its ``try`` and ``find_installations``
+    calls it unguarded, so a ``None`` stdout used to raise
+    ``AttributeError: 'NoneType' object has no attribute 'strip'`` straight
+    into the popup's update path.
+    """
+
+    def setUp(self):
+        claude_cli._version_cache.clear()
+        claude_cli._command_version_cache.clear()
+
+    @patch('usage_monitor_for_claude.claude_cli.subprocess.run')
+    @patch('pathlib.Path.stat', return_value=MagicMock(st_mtime=1000.0))
+    def test_cli_version_decodes_output_as_utf8(self, _mock_stat, mock_run):
+        """cli_version decodes --version output as UTF-8, not the locale codec."""
+        mock_run.return_value = MagicMock(stdout='2.1.69 (Claude Code)\n', returncode=0)
+        cli_version(Path('/fake/claude.exe'))
+        _args, kwargs = mock_run.call_args
+        self.assertEqual(kwargs.get('encoding'), 'utf-8')
+        self.assertEqual(kwargs.get('errors'), 'replace')
+
+    @patch('usage_monitor_for_claude.claude_cli.subprocess.run')
+    def test_command_version_decodes_output_as_utf8(self, mock_run):
+        """_command_version decodes --version output as UTF-8, not the locale codec."""
+        mock_run.return_value = MagicMock(stdout='2.1.204 (Claude Code)\n', returncode=0)
+        claude_cli._command_version(['wsl', 'claude'])
+        _args, kwargs = mock_run.call_args
+        self.assertEqual(kwargs.get('encoding'), 'utf-8')
+        self.assertEqual(kwargs.get('errors'), 'replace')
+
+    @patch('usage_monitor_for_claude.claude_cli.subprocess.run')
+    def test_command_version_survives_none_stdout(self, mock_run):
+        """A None stdout (dead decode thread) returns '' instead of raising.
+
+        This is the exact reported traceback for the custom-command path:
+        ``_parse_version(proc.stdout)`` sits outside the ``try``, so a None
+        stdout raised ``AttributeError`` before this fix.
+        """
+        mock_run.return_value = MagicMock(stdout=None, stderr=None, returncode=0)
+        self.assertEqual(claude_cli._command_version(['wsl', 'claude']), '')
+
+    @patch('usage_monitor_for_claude.claude_cli.subprocess.run')
+    @patch('pathlib.Path.stat', return_value=MagicMock(st_mtime=1000.0))
+    def test_cli_version_survives_none_stdout(self, _mock_stat, mock_run):
+        """cli_version returns '' (never raises) on a None stdout."""
+        mock_run.return_value = MagicMock(stdout=None, returncode=0)
+        self.assertEqual(cli_version(Path('/fake/claude.exe')), '')
+
+    @patch('usage_monitor_for_claude.claude_cli.subprocess.run')
+    @patch('usage_monitor_for_claude.claude_cli.CLI_COMMAND', {'WSL': ['wsl', 'claude']})
+    @patch('usage_monitor_for_claude.claude_cli._EXTENSION_DIRS', [])
+    @patch('usage_monitor_for_claude.claude_cli.CLAUDE_CLI_PATH')
+    def test_find_installations_survives_none_command_stdout(self, mock_path, mock_run):
+        """A configured cli_command whose --version stdout is None must not
+        crash find_installations() - the popup's update path (regression #80)."""
+        mock_path.is_file.return_value = False
+        mock_run.return_value = MagicMock(stdout=None, stderr=None, returncode=0)
+        result = find_installations()  # must not raise AttributeError
+        self.assertEqual(result, [])
 
 
 if __name__ == '__main__':

--- a/usage_monitor_for_claude/claude_cli.py
+++ b/usage_monitor_for_claude/claude_cli.py
@@ -237,9 +237,13 @@ def cli_version(path: Path) -> str:
 
         proc = subprocess.run(
             [str(path), '--version'],
-            capture_output=True, text=True, timeout=10, creationflags=subprocess.CREATE_NO_WINDOW,
+            capture_output=True, text=True, encoding='utf-8', errors='replace',
+            timeout=10, creationflags=subprocess.CREATE_NO_WINDOW,
         )
-        version = _parse_version(proc.stdout)
+        # ``claude --version`` emits UTF-8; decode it as UTF-8 (not the ambient
+        # locale codec, e.g. cp950) so a non-ASCII glyph cannot kill the
+        # pipe-reader thread and leave ``proc.stdout`` as None (#80).
+        version = _parse_version(proc.stdout or '')
         _version_cache[path] = (mtime, version)
         return version
     except Exception:
@@ -260,12 +264,18 @@ def _command_version(command: list[str]) -> str:
     try:
         proc = subprocess.run(
             [*command, '--version'],
-            capture_output=True, text=True, timeout=10, creationflags=subprocess.CREATE_NO_WINDOW,
+            capture_output=True, text=True, encoding='utf-8', errors='replace',
+            timeout=10, creationflags=subprocess.CREATE_NO_WINDOW,
         )
     except Exception:
         return ''
 
-    version = _parse_version(proc.stdout)
+    # ``--version`` output is UTF-8; decode it as UTF-8 above (not the ambient
+    # locale codec) so a non-ASCII glyph cannot kill the pipe-reader thread and
+    # leave ``proc.stdout`` as None.  This parse runs outside the ``try`` and
+    # find_installations() calls this unguarded, so also defend against a None
+    # stdout here rather than raising AttributeError into the popup (#80).
+    version = _parse_version(proc.stdout or '')
     _command_version_cache[key] = version
     return version
 

--- a/usage_monitor_for_claude/claude_cli.py
+++ b/usage_monitor_for_claude/claude_cli.py
@@ -185,14 +185,18 @@ def refresh_token() -> RefreshResult:
     try:
         proc = subprocess.run(
             [str(CLAUDE_CLI_PATH), 'update'],
-            capture_output=True, text=True, timeout=60, creationflags=subprocess.CREATE_NO_WINDOW,
+            capture_output=True, text=True, encoding='utf-8', errors='replace',
+            timeout=60, creationflags=subprocess.CREATE_NO_WINDOW,
         )
     except subprocess.TimeoutExpired:
         return RefreshResult(success=False, updated=False, old_version='', new_version='', error='Timeout')
     except OSError as e:
         return RefreshResult(success=False, updated=False, old_version='', new_version='', error=str(e))
 
-    output = proc.stdout + proc.stderr
+    # ``claude update`` emits UTF-8; decoding it with the ambient locale codec
+    # (e.g. cp950) can kill the pipe-reader thread and leave a stream as None,
+    # so decode as UTF-8 above and defend against a None stream here (#80).
+    output = (proc.stdout or '') + (proc.stderr or '')
 
     # Parse: "Successfully updated from X.Y.Z to version A.B.C"
     update_match = re.search(r'updated from (\S+) to (?:version )?(\S+)', output)


### PR DESCRIPTION
## Summary

Fixes #80 — a crash during automatic token refresh on non-UTF-8 system locales (e.g. Traditional Chinese / **cp950**).

`refresh_token()` runs `claude update` with `text=True` but **no explicit `encoding`**, so the child's pipes are decoded with the ambient locale codec. `claude update` emits UTF-8; on a non-UTF-8 locale the first non-ASCII glyph makes the decode raise **inside `communicate()`'s pipe-reader thread**. That thread dies, CPython returns `None` for the stream, and the next line — `proc.stdout + proc.stderr` — raises:

```
TypeError: can only concatenate str (not "NoneType") to str
```

The token refresh itself had already succeeded; only the poll thread died, so the tray icon froze and stopped updating.

## Fix

1. Decode as UTF-8 explicitly: `encoding='utf-8', errors='replace'`. This matches what the Claude CLI actually emits and makes decoding independent of the system locale (and `errors='replace'` guarantees the reader thread can never raise on unexpected bytes).
2. Harden the concatenation: `output = (proc.stdout or '') + (proc.stderr or '')`, so a `None` stream can never raise `TypeError`.

Two changed source lines. The subsequent version-parsing is unchanged; an empty string simply produces no regex match, exactly as before.

### Scope
The two sibling helpers `cli_version()` and `_command_version()` share the same `subprocess.run(..., text=True)` pattern, but each is wrapped in `except Exception: return ''`, so on a decode failure they degrade to an empty version string rather than crashing. I left them untouched to keep this change scoped to the reported crash — happy to follow up on them separately if you'd like them hardened too.

## Tests

Added `TestRefreshTokenNonUtf8Locale` (3 cases) to `tests/test_claude_cli.py`:

- `test_decodes_output_as_utf8_regardless_of_locale` — asserts `encoding='utf-8', errors='replace'` are passed.
- `test_survives_none_stderr_from_dead_pipe_thread` — reproduces the exact reported scenario (successful update line on stdout, `stderr=None`); fails with the reported `TypeError` on the unpatched code, passes with the fix.
- `test_survives_both_streams_none` — both streams `None`, returncode 0.

All three fail on the unpatched code and pass with the fix; the full `test_claude_cli` suite (54 tests) passes.

*(Verified locally on Linux by stubbing the Windows-only `ctypes.windll` / `subprocess.CREATE_NO_WINDOW` at import; no repo files were changed for that — the shim lives outside the tree.)*
