### PR TITLE
refactor: derive the config directory from instance_id everywhere

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,6 +18,7 @@ from usage_monitor_for_claude.api import (
     fetch_prepaid_credits, fetch_usage, read_access_token,
 )
 from usage_monitor_for_claude.i18n import LOCALE_DIR
+from usage_monitor_for_claude.instance_id import effective_config_dir
 
 EN = json.loads((LOCALE_DIR / 'en.json').read_text(encoding='utf-8'))
 
@@ -39,8 +40,9 @@ class TestClaudeConfigDir(unittest.TestCase):
                 import usage_monitor_for_claude.api as api_mod
                 importlib.reload(api_mod)
                 try:
-                    self.assertEqual(api_mod.CLAUDE_CONFIG_DIR, Path.home() / '.claude')
-                    self.assertEqual(api_mod.CLAUDE_CREDENTIALS, Path.home() / '.claude' / '.credentials.json')
+                    expected = (Path.home() / '.claude').resolve()
+                    self.assertEqual(api_mod.CLAUDE_CONFIG_DIR, expected)
+                    self.assertEqual(api_mod.CLAUDE_CREDENTIALS, expected / '.credentials.json')
                 finally:
                     importlib.reload(api_mod)
 
@@ -52,8 +54,24 @@ class TestClaudeConfigDir(unittest.TestCase):
                 import usage_monitor_for_claude.api as api_mod
                 importlib.reload(api_mod)
                 try:
-                    self.assertEqual(api_mod.CLAUDE_CONFIG_DIR, Path(tmp))
-                    self.assertEqual(api_mod.CLAUDE_CREDENTIALS, Path(tmp) / '.credentials.json')
+                    self.assertEqual(api_mod.CLAUDE_CONFIG_DIR, Path(tmp).resolve())
+                    self.assertEqual(api_mod.CLAUDE_CREDENTIALS, Path(tmp).resolve() / '.credentials.json')
+                finally:
+                    importlib.reload(api_mod)
+
+    def test_matches_instance_id_helper(self):
+        """The credentials directory is the one instance_id derives for this instance."""
+        with TemporaryDirectory() as tmp:
+            # A spelling that only compares equal once resolved, so an inlined
+            # derivation that skips the resolution fails this assertion.
+            (Path(tmp) / 'sub').mkdir()
+            with patch.dict('os.environ', {'CLAUDE_CONFIG_DIR': str(Path(tmp) / 'sub' / '..')}):
+                import importlib
+                import usage_monitor_for_claude.api as api_mod
+                importlib.reload(api_mod)
+                try:
+                    self.assertEqual(api_mod.CLAUDE_CONFIG_DIR, effective_config_dir())
+                    self.assertEqual(api_mod.CLAUDE_CONFIG_DIR, Path(tmp).resolve())
                 finally:
                     importlib.reload(api_mod)
 
@@ -64,7 +82,7 @@ class TestClaudeConfigDir(unittest.TestCase):
             import usage_monitor_for_claude.api as api_mod
             importlib.reload(api_mod)
             try:
-                self.assertEqual(api_mod.CLAUDE_CONFIG_DIR, Path.home() / '.claude')
+                self.assertEqual(api_mod.CLAUDE_CONFIG_DIR, (Path.home() / '.claude').resolve())
             finally:
                 importlib.reload(api_mod)
 

--- a/tests/test_verbose.py
+++ b/tests/test_verbose.py
@@ -11,6 +11,7 @@ import os
 import sys
 import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
 
 from usage_monitor_for_claude.verbose import (
@@ -138,41 +139,27 @@ class TestCredentialsStatus(unittest.TestCase):
 
     def test_found(self):
         """Reports 'found' with path when credentials file exists."""
-        with patch('usage_monitor_for_claude.verbose.Path') as mock_path, \
-             patch.dict('os.environ', {}, clear=False):
-            env = {k: v for k, v in __import__('os').environ.items() if k != 'CLAUDE_CONFIG_DIR'}
-            with patch.dict('os.environ', env, clear=True):
-                mock_home = MagicMock()
-                mock_path.home.return_value = mock_home
-                cred_path = mock_home / '.claude' / '.credentials.json'
-                cred_path.exists.return_value = True
+        with TemporaryDirectory() as tmp:
+            (Path(tmp) / '.credentials.json').write_text('{}', encoding='utf-8')
+            with patch.dict('os.environ', {'CLAUDE_CONFIG_DIR': tmp}):
                 result = _credentials_status()
         self.assertTrue(result.startswith('found'))
 
     def test_not_found(self):
         """Reports 'NOT FOUND' with path when credentials file is missing."""
-        with patch('usage_monitor_for_claude.verbose.Path') as mock_path, \
-             patch.dict('os.environ', {}, clear=False):
-            env = {k: v for k, v in __import__('os').environ.items() if k != 'CLAUDE_CONFIG_DIR'}
-            with patch.dict('os.environ', env, clear=True):
-                mock_home = MagicMock()
-                mock_path.home.return_value = mock_home
-                cred_path = mock_home / '.claude' / '.credentials.json'
-                cred_path.exists.return_value = False
+        with TemporaryDirectory() as tmp:
+            with patch.dict('os.environ', {'CLAUDE_CONFIG_DIR': tmp}):
                 result = _credentials_status()
         self.assertTrue(result.startswith('NOT FOUND'))
 
     def test_custom_config_dir(self):
         """Respects CLAUDE_CONFIG_DIR environment variable."""
-        with patch('usage_monitor_for_claude.verbose.Path') as mock_path, \
-             patch.dict('os.environ', {'CLAUDE_CONFIG_DIR': 'D:\\custom'}):
-            custom_path = MagicMock()
-            mock_path.return_value = custom_path
-            cred_path = custom_path / '.credentials.json'
-            cred_path.exists.return_value = True
-            result = _credentials_status()
-        mock_path.assert_called_with('D:\\custom')
+        with TemporaryDirectory() as tmp:
+            (Path(tmp) / '.credentials.json').write_text('{}', encoding='utf-8')
+            with patch.dict('os.environ', {'CLAUDE_CONFIG_DIR': tmp}):
+                result = _credentials_status()
         self.assertTrue(result.startswith('found'))
+        self.assertIn(Path(tmp).name, result)
 
 
 class TestPrintStartupDiagnostics(unittest.TestCase):

--- a/tests/test_verbose.py
+++ b/tests/test_verbose.py
@@ -26,6 +26,24 @@ from usage_monitor_for_claude.verbose import (
 )
 
 
+def _symlinked_home(tmp: str) -> Path:
+    """Build a home directory reached through a symlink inside ``tmp``.
+
+    Skips the calling test where the platform does not let this process
+    create one (Windows without Developer Mode).
+    """
+    real_home = Path(tmp) / 'realhome'
+    real_home.mkdir()
+    linked_home = Path(tmp) / 'linkhome'
+
+    try:
+        linked_home.symlink_to(real_home, target_is_directory=True)
+    except (OSError, NotImplementedError) as error:
+        raise unittest.SkipTest(f'symlink creation unavailable: {error}') from error
+
+    return linked_home
+
+
 class TestRedactHome(unittest.TestCase):
     """Tests for _redact_home() path sanitization."""
 
@@ -71,6 +89,29 @@ class TestRedactHome(unittest.TestCase):
         """The home directory itself is redacted to ~."""
         home = str(Path.home())
         self.assertEqual(_redact_home(home), '~')
+
+    def test_symlinked_home_redacted_in_both_spellings(self):
+        """Where the home directory is reached through a symlink or a junction,
+        the linked and the resolved spelling name the same directory - a path
+        that arrives already resolved (the credentials file) must be redacted
+        just like one that keeps the linked spelling (``sys.executable``)."""
+        with TemporaryDirectory() as tmp:
+            linked_home = _symlinked_home(tmp)
+
+            with patch.object(Path, 'home', return_value=linked_home):
+                resolved = str(linked_home.resolve() / '.claude' / '.credentials.json')
+                self.assertEqual(_redact_home(resolved), f'~{os.sep}.claude{os.sep}.credentials.json')
+                self.assertEqual(_redact_home(str(linked_home / 'venv' / 'python')), f'~{os.sep}venv{os.sep}python')
+
+
+    def test_unresolvable_home_still_redacts(self):
+        """Resolving the home directory fails behind a symlink loop and on an
+        unreachable network path - the diagnostics must still print, with the
+        literal spelling redacted as before."""
+        home = str(Path.home())
+        for error in (RuntimeError('Symlink loop'), OSError('network path unavailable')):
+            with self.subTest(error=type(error).__name__), patch.object(Path, 'resolve', side_effect=error):
+                self.assertEqual(_redact_home(f'{home}{os.sep}.claude'), f'~{os.sep}.claude')
 
 
 class TestSection(unittest.TestCase):
@@ -138,19 +179,43 @@ class TestCredentialsStatus(unittest.TestCase):
     """Tests for _credentials_status()."""
 
     def test_found(self):
-        """Reports 'found' with path when credentials file exists."""
-        with TemporaryDirectory() as tmp:
-            (Path(tmp) / '.credentials.json').write_text('{}', encoding='utf-8')
-            with patch.dict('os.environ', {'CLAUDE_CONFIG_DIR': tmp}):
+        """Reports 'found' with the redacted default path when the file exists."""
+        with TemporaryDirectory() as home_tmp:
+            claude_dir = Path(home_tmp) / '.claude'
+            claude_dir.mkdir()
+            (claude_dir / '.credentials.json').write_text('{}', encoding='utf-8')
+            with patch.object(Path, 'home', return_value=Path(home_tmp)), patch.dict('os.environ', {}, clear=False):
+                os.environ.pop('CLAUDE_CONFIG_DIR', None)
                 result = _credentials_status()
         self.assertTrue(result.startswith('found'))
+        self.assertIn(f'~{os.sep}.claude{os.sep}.credentials.json', result)
 
     def test_not_found(self):
-        """Reports 'NOT FOUND' with path when credentials file is missing."""
-        with TemporaryDirectory() as tmp:
-            with patch.dict('os.environ', {'CLAUDE_CONFIG_DIR': tmp}):
+        """Reports 'NOT FOUND' with the redacted default path when the file is missing."""
+        with TemporaryDirectory() as home_tmp:
+            (Path(home_tmp) / '.claude').mkdir()
+            with patch.object(Path, 'home', return_value=Path(home_tmp)), patch.dict('os.environ', {}, clear=False):
+                os.environ.pop('CLAUDE_CONFIG_DIR', None)
                 result = _credentials_status()
         self.assertTrue(result.startswith('NOT FOUND'))
+        self.assertIn(f'~{os.sep}.claude{os.sep}.credentials.json', result)
+
+    def test_symlinked_home_stays_redacted(self):
+        """The credentials path is resolved before it is printed - with the home
+        directory reached through a symlink the row must still show ~, because
+        this is the dump users paste into public issues."""
+        with TemporaryDirectory() as tmp:
+            linked_home = _symlinked_home(tmp)
+            (linked_home / '.claude').mkdir()
+            (linked_home / '.claude' / '.credentials.json').write_text('{}', encoding='utf-8')
+
+            with patch.object(Path, 'home', return_value=linked_home), patch.dict('os.environ', {}, clear=False):
+                os.environ.pop('CLAUDE_CONFIG_DIR', None)
+                result = _credentials_status()
+
+            self.assertTrue(result.startswith('found'))
+            self.assertIn(f'~{os.sep}.claude{os.sep}.credentials.json', result)
+            self.assertNotIn(str(linked_home.resolve()), result)
 
     def test_custom_config_dir(self):
         """Respects CLAUDE_CONFIG_DIR environment variable."""

--- a/usage_monitor_for_claude/api.py
+++ b/usage_monitor_for_claude/api.py
@@ -12,15 +12,14 @@ TLS certificates are verified against the Windows certificate store.
 from __future__ import annotations
 
 import json
-import os
 import re
-from pathlib import Path
 from typing import Any
 
 import requests
 import truststore
 
 from .i18n import T
+from .instance_id import effective_config_dir
 
 __all__ = [
     'API_URL_USAGE', 'API_URL_PROFILE', 'API_URL_PREPAID_CREDITS', 'CLAUDE_CONFIG_DIR', 'CLAUDE_CREDENTIALS',
@@ -31,7 +30,7 @@ __all__ = [
 API_URL_USAGE = 'https://api.anthropic.com/api/oauth/usage'
 API_URL_PROFILE = 'https://api.anthropic.com/api/oauth/profile'
 API_URL_PREPAID_CREDITS = 'https://api.anthropic.com/api/oauth/organizations/{org_uuid}/prepaid/credits'
-CLAUDE_CONFIG_DIR = Path(os.environ.get('CLAUDE_CONFIG_DIR', '')) if os.environ.get('CLAUDE_CONFIG_DIR') else Path.home() / '.claude'
+CLAUDE_CONFIG_DIR = effective_config_dir()
 CLAUDE_CREDENTIALS = CLAUDE_CONFIG_DIR / '.credentials.json'
 _FALLBACK_USER_AGENT = 'claude-code/2.1.204'
 _ORG_UUID_PATTERN = re.compile(r'\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\Z')

--- a/usage_monitor_for_claude/verbose.py
+++ b/usage_monitor_for_claude/verbose.py
@@ -44,6 +44,22 @@ def _package_version(name: str) -> str:
         return 'not found'
 
 
+def _home_spellings() -> tuple[str, ...]:
+    """Return the home directory as it is spelled and as it resolves.
+
+    Resolving fails on a home directory behind a symlink loop (a
+    ``RuntimeError`` up to Python 3.12) and on an unreachable network
+    path.  The diagnostics have to print either way, so only the literal
+    spelling is compared there.
+    """
+    home_dir = Path.home()
+
+    try:
+        return (str(home_dir), str(home_dir.resolve()))
+    except (OSError, RuntimeError):
+        return (str(home_dir),)
+
+
 def _redact_home(path_str: str) -> str:
     """Replace the user's home directory with ``~`` to avoid exposing the username.
 
@@ -51,15 +67,24 @@ def _redact_home(path_str: str) -> str:
     ``CLAUDE_CONFIG_DIR`` set externally may be differently cased) and
     boundary-aware, so a sibling profile whose name merely starts with the
     username is not partially redacted.
-    """
-    home = str(Path.home())
-    normalized_path = os.path.normcase(path_str)
-    normalized_home = os.path.normcase(home)
 
-    if normalized_path == normalized_home:
-        return '~'
-    if normalized_path.startswith(normalized_home + os.sep):
-        return '~' + path_str[len(home):]
+    Both the literal and the resolved spelling of the home directory are
+    compared, because the paths reaching this function differ: the
+    credentials path arrives resolved, while ``sys.executable``,
+    ``sys._MEIPASS`` and the ``CLAUDE_CONFIG_DIR`` row keep the spelling
+    they were given.  Where the home directory is reached through a symlink
+    or a junction those two spellings differ, and matching only one of them
+    would print the username in full.
+    """
+    normalized_path = os.path.normcase(path_str)
+
+    for home_spelling in _home_spellings():
+        normalized_home = os.path.normcase(home_spelling)
+
+        if normalized_path == normalized_home:
+            return '~'
+        if normalized_path.startswith(normalized_home + os.sep):
+            return '~' + path_str[len(home_spelling):]
 
     return path_str
 

--- a/usage_monitor_for_claude/verbose.py
+++ b/usage_monitor_for_claude/verbose.py
@@ -16,6 +16,7 @@ import os
 import sys
 from pathlib import Path
 
+from .instance_id import effective_config_dir
 from .platforms import (
     DIAGNOSTIC_PACKAGES, diagnostic_display_rows, diagnostic_post_init_rows,
     diagnostic_runtime_rows, diagnostic_system_rows, setup_console,
@@ -65,8 +66,7 @@ def _redact_home(path_str: str) -> str:
 
 def _credentials_status() -> str:
     """Check if the credentials file exists (never reads its content)."""
-    config_dir = Path(os.environ.get('CLAUDE_CONFIG_DIR', '')) if os.environ.get('CLAUDE_CONFIG_DIR') else Path.home() / '.claude'
-    cred_path = config_dir / '.credentials.json'
+    cred_path = effective_config_dir() / '.credentials.json'
     display_path = _redact_home(str(cred_path))
 
     if cred_path.exists():


### PR DESCRIPTION
## Summary

`instance_id.effective_config_dir()` already resolves the effective Claude config
directory, and `app.py`, `settings.py`, `platforms/win32.py`, `platforms/linux.py`
and both `platforms/instance_*.py` modules use it. `api.py` and `verbose.py` did
not - each one re-derived the same path inline:

```python
Path(os.environ.get('CLAUDE_CONFIG_DIR', '')) if os.environ.get('CLAUDE_CONFIG_DIR') else Path.home() / '.claude'
```

The two inline copies differ from the helper in one detail: they skip the
`.resolve()` that `effective_config_dir()` applies, so the credentials were
addressed through a different spelling of the directory than every other module
derives. `__main__.py` already resolves the `--config-dir` value before writing
it into the environment, so the spellings could only diverge for an externally
set `CLAUDE_CONFIG_DIR`.

Both call sites now use the helper. `api.py` no longer needs `os` or `pathlib`.

## Workflow checklist

- [x] Read [`.claude/CLAUDE.md`](../blob/main/.claude/CLAUDE.md) and followed the project conventions
- [x] Ran the `/review` slash command on all staged changes (code, tests, documentation)
- [x] Used `/commit-message` to generate the commit message(s)
- [x] Ran the full test suite: `python -m unittest discover -s tests` (1205 tests, OK, 8 skipped)

## User-facing changes

Internal only - no user-visible behaviour change, no new or changed strings.

- [ ] `README.md` feature list updated
- [ ] `docs/configuration.md` updated (if configuration changed)
- [ ] Locale files in `locale/` updated (if user-visible strings changed)

## Notes for reviewers

- **No user-visible symptom is known.** I could not construct a case where the
  unresolved spelling actually reads the wrong file: through `--config-dir` the
  value arrives already resolved, and for an externally set `CLAUDE_CONFIG_DIR`
  both spellings still land on the same file - I checked the symlink case on
  Linux, where the two paths differ but `os.path.samefile()` holds. This is
  consistency between modules rather than a bug fix, so please retype the commit
  if you would rather have it as `chore:`.

- **Import direction.** `api.py` -> `instance_id` is safe: `instance_id` imports
  only the standard library, and the rule in `CLAUDE.md` ("must stay free of
  imports from `api` or `settings`") constrains the other direction. `api.py` is
  not among the modules `__main__.py` imports before it settles
  `CLAUDE_CONFIG_DIR`, so the constant is still evaluated at exactly the same
  moment as before.

- **`tests/test_api.py`** now asserts the resolved path, and
  `test_matches_instance_id_helper` pins the invariant. It points
  `CLAUDE_CONFIG_DIR` at a spelling that only compares equal once resolved
  (`<tmp>/sub/..`) rather than at a plain temporary directory, so it actually
  fails against the inlined derivation instead of passing on both sides - I
  checked that by reverting the module and running the class.

- **`tests/test_verbose.py`** - `TestCredentialsStatus` patched
  `usage_monitor_for_claude.verbose.Path` wholesale, which also replaced the
  `Path.home()` call inside `_redact_home()`. With the derivation moved into the
  helper that mock no longer intercepts anything, so the class uses real
  temporary directories instead: `test_found` and `test_not_found` patch
  `Path.home` and stay on the default `~/.claude` branch,
  `test_custom_config_dir` is the only `CLAUDE_CONFIG_DIR` case, and a symlinked
  home pins the redaction in both spellings. They exercise the real `exists()`
  rather than a configured return value.

- **`verbose.py` now shows two related values.** The `CLAUDE_CONFIG_DIR` row still
  prints the raw environment variable, while the credentials row prints the
  resolved path. That looked deliberate to me for a diagnostics dump - you can
  see both what was set and where it landed - so I left it. Say the word if you
  would rather have them agree.

- **`CLAUDE.md` untouched.** The invariant would fit under `Security & Transparency`
  as a one-liner, next to the note that `api.py` is the only module handling
  credentials. I did not want to edit the conventions file unasked - happy to add
  it if you want it written down.

- Checked besides the suite: `pyright` reports nothing on the four changed
  files (the one pre-existing finding in `api.py` is far from the diff);
  `print_startup_diagnostics()` was run for real, since the unit tests around it
  mock more than they prove; and the path handling was re-checked on Linux, where
  `effective_config_dir()` resolves the same way and the new test discriminates
  the same way. The suite itself I ran on Windows only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

